### PR TITLE
feat: add wlr-layer-shell support for rofi/wofi

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,28 @@ M-x emskin-open-native-app RET mpv foo.mp4 — 启动 mpv 播放视频
 
 应用启动后会自动获取焦点，窗口位置由 Emacs 通过 IPC 控制。
 
+**启动器**（rofi/wofi 等 wlr-layer-shell 应用）：
+
+emskin 支持 wlr-layer-shell 协议，可以直接运行 rofi/wofi 等启动器。Emacs 内部运行在 emskin 中，`start-process` 启动的程序自动连接到 emskin，无需额外配置。
+
+在 init.el 中绑定快捷键：
+
+```elisp
+(defun my/emskin-rofi ()
+  "Launch rofi application launcher."
+  (interactive)
+  (start-process "rofi" nil
+                 "setsid" "rofi"
+                 "-combi-modi" "drun,ssh"
+                 "-show" "combi"
+                 "-terminal" "foot"
+                 "-font" "JetBrainsMono Nerd Font"
+                 "-show-icons" "-i"))
+(global-set-key (kbd "C-c r") #'my/emskin-rofi)
+```
+
+> **提示**：使用 `setsid` 让 rofi 在独立会话中运行，确保从 rofi 启动的程序不受 Emacs 进程组影响。
+
 ## 项目结构
 
 ```

--- a/emskin/CLAUDE.md
+++ b/emskin/CLAUDE.md
@@ -66,6 +66,10 @@
 - Clipboard startup guard: use `!self.ipc.is_connected()` instead of per-target bool flags — GTK clipboard init happens before emskin.el connects, real user copies happen after. Works for both pgtk (SelectionHandler) and gtk3 (XwmHandler) paths
 - X11 cursor tracking: `cursor_x11.rs` opens an independent X11 connection (explicit `:{display}`, NOT `DISPLAY` env var) to XWayland, subscribes to XFixes `CursorNotifyMask::DISPLAY_CURSOR` on root window, maps cursor name atoms to `CursorIcon` via `get_atom_name`. Dispatched in `post_render` via `poll_for_event` (non-blocking). `broken` flag stops polling after connection error. Requires XFixes v2+
 - X11 cursor: `SeatHandler::cursor_image` is NEVER called for X11 clients — XWayland doesn't forward X11 cursor changes via `wl_pointer.set_cursor`. Must use XFixes cursor tracking instead
+- Layer shell (wlr-layer-shell): uses smithay's `LayerMap` + `DesktopLayerSurface` (not manual Vec). `layer_map_for_output` returns MutexGuard — collect data and drop guard before calling renderer or keyboard.set_focus. Frame callbacks: collect layers, drop guard, then send_frame
+- Layer shell keyboard focus timing: `new_layer_surface` fires on `get_layer_surface` (BEFORE initial commit) — cached_state has no keyboard_interactivity yet. Must defer focus to compositor commit handler where `can_receive_keyboard_focus()` works correctly
+- Layer shell destroy: only reclaim focus if `keyboard.current_focus() == destroyed surface` — unconditional fallback steals focus from other active windows
+- Code language: all comments, tracing logs, and doc comments must be in English. No Chinese in Rust source code
 
 ## Wayland Protocols Implemented
 - xdg_shell (toplevel, popup)
@@ -76,3 +80,4 @@
 - text_input_v3 (IME bridge to host — see smithay fork patches)
 - wp_cursor_shape_v1 (cursor shape forwarding to host — Named icons via winit, Surface falls back to default)
 - linux-dmabuf (GPU buffer sharing for hardware-accelerated clients)
+- wlr-layer-shell (layer surfaces for rofi/wofi launchers — uses LayerMap for layout, keyboard focus set on first commit not on surface creation)

--- a/emskin/src/handlers/compositor.rs
+++ b/emskin/src/handlers/compositor.rs
@@ -3,6 +3,7 @@ use smithay::wayland::seat::WaylandFocus;
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
     delegate_compositor, delegate_shm,
+    desktop::{layer_map_for_output, WindowSurfaceType},
     reexports::wayland_server::{
         protocol::{wl_buffer, wl_surface::WlSurface},
         Client,
@@ -64,6 +65,41 @@ impl CompositorHandler for EmskinState {
                 tracing::debug!("embedded app window_id={window_id} geometry committed: {geo:?}");
             }
         };
+
+        // Layer surface commit: re-arrange and send pending configure.
+        // Keyboard focus is set here (not in new_layer_surface) because
+        // cached_state only has keyboard_interactivity after initial commit.
+        let layer_focus = if let Some(output) = self.space.outputs().next().cloned() {
+            let mut map = layer_map_for_output(&output);
+            let layer = map
+                .layer_for_surface(surface, WindowSurfaceType::TOPLEVEL)
+                .cloned();
+            if let Some(ref layer) = layer {
+                map.arrange();
+                drop(map);
+                layer.layer_surface().send_pending_configure();
+
+                let needs_focus = layer.can_receive_keyboard_focus();
+                let wl = layer.wl_surface().clone();
+                Some((needs_focus, wl))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        if let Some((needs_focus, wl)) = layer_focus {
+            if needs_focus {
+                if let Some(keyboard) = self.seat.get_keyboard() {
+                    if keyboard.current_focus().as_ref() != Some(&wl) {
+                        let serial = smithay::utils::SERIAL_COUNTER.next_serial();
+                        keyboard.set_focus(self, Some(wl), serial);
+                        tracing::debug!("layer surface received keyboard focus");
+                    }
+                }
+            }
+            return;
+        }
 
         xdg_shell::handle_surface_commit(&mut self.popups, &self.space, surface);
     }

--- a/emskin/src/handlers/layer_shell.rs
+++ b/emskin/src/handlers/layer_shell.rs
@@ -1,0 +1,75 @@
+use smithay::{
+    delegate_layer_shell,
+    desktop::{layer_map_for_output, LayerSurface as DesktopLayerSurface, WindowSurfaceType},
+    reexports::wayland_server::protocol::wl_output::WlOutput,
+    utils::SERIAL_COUNTER,
+    wayland::shell::wlr_layer::{Layer, LayerSurface, WlrLayerShellHandler, WlrLayerShellState},
+};
+
+use crate::EmskinState;
+
+impl WlrLayerShellHandler for EmskinState {
+    fn shell_state(&mut self) -> &mut WlrLayerShellState {
+        &mut self.layer_shell_state
+    }
+
+    fn new_layer_surface(
+        &mut self,
+        surface: LayerSurface,
+        _output: Option<WlOutput>,
+        _layer: Layer,
+        namespace: String,
+    ) {
+        let desktop_layer = DesktopLayerSurface::new(surface, namespace.clone());
+
+        let Some(output) = self.space.outputs().next().cloned() else {
+            tracing::warn!("layer_shell: no output, closing surface (namespace={namespace})");
+            desktop_layer.layer_surface().send_close();
+            return;
+        };
+
+        let mut map = layer_map_for_output(&output);
+        if let Err(e) = map.map_layer(&desktop_layer) {
+            tracing::warn!("layer_shell: map_layer failed: {e}");
+            desktop_layer.layer_surface().send_close();
+            return;
+        }
+
+        tracing::info!(
+            "layer_shell: new surface, namespace={namespace} layer={:?}",
+            desktop_layer.layer(),
+        );
+
+        desktop_layer.layer_surface().send_pending_configure();
+        drop(map);
+
+        // Keyboard focus is deferred to the compositor commit handler:
+        // new_layer_surface fires on get_layer_surface (before initial commit),
+        // so cached_state has no keyboard_interactivity yet.
+    }
+
+    fn layer_destroyed(&mut self, surface: LayerSurface) {
+        if let Some(output) = self.space.outputs().next().cloned() {
+            let mut map = layer_map_for_output(&output);
+            let found = map
+                .layer_for_surface(surface.wl_surface(), WindowSurfaceType::TOPLEVEL)
+                .cloned();
+            if let Some(layer) = found {
+                map.unmap_layer(&layer);
+            }
+            drop(map);
+        }
+
+        tracing::info!("layer_shell: surface destroyed");
+
+        // Only reclaim focus if this surface actually held it.
+        if let Some(keyboard) = self.seat.get_keyboard() {
+            if keyboard.current_focus().as_ref() == Some(surface.wl_surface()) {
+                let serial = SERIAL_COUNTER.next_serial();
+                keyboard.set_focus(self, self.emacs_surface.clone(), serial);
+            }
+        }
+    }
+}
+
+delegate_layer_shell!(EmskinState);

--- a/emskin/src/handlers/mod.rs
+++ b/emskin/src/handlers/mod.rs
@@ -1,5 +1,6 @@
 mod compositor;
 mod dmabuf;
+mod layer_shell;
 mod xdg_shell;
 mod xwayland;
 

--- a/emskin/src/state.rs
+++ b/emskin/src/state.rs
@@ -22,7 +22,10 @@ use smithay::{
         fractional_scale::FractionalScaleManagerState,
         output::OutputManagerState,
         selection::{data_device::DataDeviceState, primary_selection::PrimarySelectionState},
-        shell::xdg::{decoration::XdgDecorationState, XdgShellState},
+        shell::{
+            wlr_layer::WlrLayerShellState,
+            xdg::{decoration::XdgDecorationState, XdgShellState},
+        },
         shm::ShmState,
         socket::ListeningSocketSource,
         viewporter::ViewporterState,
@@ -73,6 +76,7 @@ pub struct EmskinState {
     pub fractional_scale_manager_state: FractionalScaleManagerState,
     pub viewporter_state: ViewporterState,
     pub xdg_decoration_state: XdgDecorationState,
+    pub layer_shell_state: WlrLayerShellState,
     pub xwayland_shell_state: XWaylandShellState,
     pub cursor_shape_manager_state: CursorShapeManagerState,
     pub dmabuf_state: DmabufState,
@@ -186,6 +190,7 @@ impl EmskinState {
         let fractional_scale_manager_state = FractionalScaleManagerState::new::<Self>(&dh);
         let viewporter_state = ViewporterState::new::<Self>(&dh);
         let xdg_decoration_state = XdgDecorationState::new::<Self>(&dh);
+        let layer_shell_state = WlrLayerShellState::new::<Self>(&dh);
         let xwayland_shell_state = XWaylandShellState::new::<Self>(&dh);
         let cursor_shape_manager_state = CursorShapeManagerState::new::<Self>(&dh);
         let text_input_manager_state =
@@ -233,6 +238,7 @@ impl EmskinState {
             fractional_scale_manager_state,
             viewporter_state,
             xdg_decoration_state,
+            layer_shell_state,
             xwayland_shell_state,
             cursor_shape_manager_state,
             dmabuf_state,
@@ -361,7 +367,12 @@ impl EmskinState {
             }
         }
 
-        // 2. Check real surfaces in the space.
+        // 2. Layer surfaces take priority over space (launchers must intercept input).
+        if let Some(hit) = self.layer_surface_under(pos) {
+            return Some(hit);
+        }
+
+        // 3. Space elements.
         self.space
             .element_under(pos)
             .and_then(|(window, location)| {
@@ -369,6 +380,33 @@ impl EmskinState {
                     .surface_under(pos - location.to_f64(), WindowSurfaceType::ALL)
                     .map(|(s, p)| (s, (p + location).to_f64()))
             })
+    }
+
+    fn layer_surface_under(
+        &self,
+        pos: Point<f64, Logical>,
+    ) -> Option<(WlSurface, Point<f64, Logical>)> {
+        use smithay::desktop::layer_map_for_output;
+        use smithay::wayland::shell::wlr_layer::Layer;
+
+        let output = self.space.outputs().next()?;
+        let map = layer_map_for_output(output);
+
+        for layer in [Layer::Overlay, Layer::Top, Layer::Bottom, Layer::Background] {
+            if let Some(surface) = map.layer_under(layer, pos) {
+                let Some(layer_geo) = map.layer_geometry(surface) else {
+                    continue;
+                };
+                let local = pos - layer_geo.loc.to_f64();
+                if let Some((wl_surface, offset)) =
+                    surface.surface_under(local, WindowSurfaceType::ALL)
+                {
+                    return Some((wl_surface, (offset + layer_geo.loc).to_f64()));
+                }
+            }
+        }
+
+        None
     }
 }
 

--- a/emskin/src/winit.rs
+++ b/emskin/src/winit.rs
@@ -6,12 +6,16 @@ use smithay::{
         renderer::{
             damage::OutputDamageTracker,
             element::{
-                memory::MemoryRenderBufferRenderElement, render_elements,
-                solid::SolidColorRenderElement, texture::TextureRenderElement, Id, Kind,
+                memory::MemoryRenderBufferRenderElement,
+                render_elements,
+                solid::SolidColorRenderElement,
+                surface::{render_elements_from_surface_tree, WaylandSurfaceRenderElement},
+                texture::TextureRenderElement,
+                Id, Kind,
             },
             gles::{GlesRenderer, GlesTexture},
             utils::{import_surface_tree, RendererSurfaceStateUserData},
-            ImportMem, Renderer,
+            ImportAll, ImportMem, Renderer,
         },
         winit::{self, WinitEvent, WinitGraphicsBackend},
     },
@@ -35,11 +39,12 @@ use crate::EmskinState;
 
 /// Blanket trait bundling renderer constraints for the `render_elements!` macro
 /// (which cannot parse associated-type bounds like `Renderer<TextureId = GlesTexture>`).
-trait EmskinRenderer: ImportMem + Renderer<TextureId = GlesTexture> {}
-impl<R: ImportMem + Renderer<TextureId = GlesTexture>> EmskinRenderer for R {}
+trait EmskinRenderer: ImportAll + ImportMem + Renderer<TextureId = GlesTexture> {}
+impl<R: ImportAll + ImportMem + Renderer<TextureId = GlesTexture>> EmskinRenderer for R {}
 
 render_elements! {
     pub CustomElement<R> where R: EmskinRenderer;
+    Surface=WaylandSurfaceRenderElement<R>,
     Mirror=TextureRenderElement<GlesTexture>,
     Solid=SolidColorRenderElement,
     Label=MemoryRenderBufferRenderElement<R>,
@@ -241,6 +246,48 @@ fn build_mirror_elements(
     elements
 }
 
+fn build_layer_surface_elements(
+    renderer: &mut GlesRenderer,
+    output: &Output,
+    scale: f64,
+) -> Vec<CustomElement<GlesRenderer>> {
+    use smithay::desktop::layer_map_for_output;
+    use smithay::wayland::shell::wlr_layer::Layer;
+
+    // Collect surface + location while holding the LayerMap guard,
+    // then drop the guard before calling the renderer (avoids holding
+    // a MutexGuard across GL operations).
+    let surface_locs: Vec<_> = {
+        let map = layer_map_for_output(output);
+        [Layer::Overlay, Layer::Top, Layer::Bottom, Layer::Background]
+            .iter()
+            .flat_map(|&layer| {
+                map.layers_on(layer)
+                    .rev()
+                    .map(|s| {
+                        let loc = map.layer_geometry(s).map(|g| g.loc).unwrap_or_default();
+                        (s.wl_surface().clone(), loc)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    };
+
+    let mut elements = Vec::new();
+    for (wl_surface, loc) in &surface_locs {
+        let layer_elements: Vec<CustomElement<GlesRenderer>> = render_elements_from_surface_tree(
+            renderer,
+            wl_surface,
+            loc.to_physical_precise_round(scale),
+            scale,
+            1.0,
+            Kind::Unspecified,
+        );
+        elements.extend(layer_elements);
+    }
+    elements
+}
+
 fn render_frame(
     state: &mut EmskinState,
     backend: &mut WinitGraphicsBackend<GlesRenderer>,
@@ -264,10 +311,11 @@ fn render_frame(
         // smithay's damage tracker renders elements via
         // `render_elements.iter().rev()`, so **the first element in the vec
         // is the topmost layer**. Layer order (top → bottom):
-        //   1. Skeleton labels  (text on top of everything, per user request)
-        //   2. Skeleton borders
-        //   3. Crosshair label + lines
-        //   4. Mirror texture elements (popups → toplevel)
+        //   1. Software cursor
+        //   2. Skeleton labels / borders (debug overlay)
+        //   3. Crosshair label + lines (debug overlay)
+        //   4. Layer shell surfaces (Overlay → Top → Bottom → Background)
+        //   5. Mirror texture elements (popups → toplevel)
         let scale = output.current_scale().fractional_scale();
         let mut custom_elements: Vec<CustomElement<GlesRenderer>> = Vec::new();
 
@@ -333,7 +381,7 @@ fn render_frame(
             custom_elements.push(s.into());
         }
 
-        // Crosshair: above mirrors, below skeleton.
+        // Crosshair: above layer surfaces, below skeleton.
         if let Some(pointer) = state.seat.get_pointer() {
             let cursor = pointer.current_location();
             let (solids, label) = state
@@ -346,6 +394,9 @@ fn render_frame(
                 custom_elements.push(s.into());
             }
         }
+
+        // Layer surfaces: above mirrors, below debug overlays.
+        custom_elements.extend(build_layer_surface_elements(renderer, output, scale));
 
         // Mirrors: bottom of the custom layer stack.
         custom_elements.extend(build_mirror_elements(state, renderer, scale));
@@ -381,6 +432,21 @@ fn post_render(state: &mut EmskinState, output: &Output) {
             |_, _| Some(output.clone()),
         )
     });
+
+    // Layer surfaces: send frame callbacks and clean up dead ones.
+    {
+        use smithay::desktop::layer_map_for_output;
+        let mut map = layer_map_for_output(output);
+        let layers: Vec<_> = map.layers().cloned().collect();
+        map.cleanup();
+        drop(map);
+        let elapsed = state.start_time.elapsed();
+        for layer in &layers {
+            layer.send_frame(output, elapsed, Some(Duration::ZERO), |_, _| {
+                Some(output.clone())
+            });
+        }
+    }
 
     state.space.refresh();
     state.popups.cleanup();


### PR DESCRIPTION
## Summary

- Implement wlr-layer-shell protocol using smithay's `LayerMap` + `DesktopLayerSurface`
- Layer surfaces (rofi, wofi, etc.) can now run inside the nested compositor
- Keyboard focus deferred to compositor commit handler (new_layer_surface fires before initial commit, so cached_state has no keyboard_interactivity yet)
- Rendering: collect surface data from LayerMap, drop MutexGuard before calling renderer
- Input: layer surfaces checked before space elements (Overlay → Top → Bottom → Background)
- Focus only reclaimed on destroy if the destroyed surface actually held focus

## Test plan

- [ ] Launch emskin, open a terminal (alacritty/foot)
- [ ] Run `rofi -show combi` from terminal — verify rofi appears and receives keyboard input
- [ ] Select a program in rofi — verify it launches inside emskin
- [ ] Press Escape to dismiss rofi — verify focus returns to previous window
- [ ] Bind `C-c r` in Emacs to launch rofi via `(start-process "rofi" nil "setsid" "rofi" ...)` — verify it works from Emacs directly