### PR TITLE
ci: add clippy, fmt checks and pin Rust 1.92.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check / Clippy / Fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwayland-dev \
+            libxkbcommon-dev \
+            libudev-dev \
+            libinput-dev \
+            libgbm-dev \
+            libseat-dev \
+            libpixman-1-dev \
+            libssl-dev \
+            libx11-xcb-dev \
+            libxcb1-dev \
+            libxcb-composite0-dev \
+            libxcb-xfixes0-dev \
+            libxcb-xinput-dev \
+            libxcb-render0-dev \
+            libxcb-shape0-dev \
+            libxcb-dri3-dev \
+            libxcb-present-dev \
+            libxcb-sync-dev \
+            libxcb-randr0-dev \
+            libxcb-shm0-dev \
+            libxcb-xkb-dev \
+            libxcb-dpms0-dev \
+            libxcb-res0-dev \
+            libxcb-cursor-dev \
+            libxcb-icccm4-dev \
+            libxkbcommon-x11-dev \
+            libfontconfig1-dev \
+            libfreetype-dev
+
+      - name: Install Rust toolchain (from emskin/rust-toolchain.toml)
+        working-directory: emskin
+        run: rustup show
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            emskin/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('emskin/Cargo.lock', 'emskin/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Fmt
+        working-directory: emskin
+        run: cargo fmt --check
+
+      - name: Clippy
+        working-directory: emskin
+        run: cargo clippy -- -D warnings
+
+      - name: Build
+        working-directory: emskin
+        run: cargo build

--- a/emskin/rust-toolchain.toml
+++ b/emskin/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.92.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow (`fmt --check` + `clippy -D warnings` + `cargo build`)
- Pin Rust toolchain to 1.92.0 via `emskin/rust-toolchain.toml` (includes clippy + rustfmt components)
- CI reads toolchain version from `rust-toolchain.toml` via `rustup show` — single source of truth

## Test plan
- [x] CI workflow triggers on push to this PR branch
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo build` succeeds