### PR TITLE
feat: cursor trail effect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ The built-in overlays:
 - `measure` — crosshair + rulers (pixel inspector)
 - `skeleton` — wireframe debug overlay with clickable labels
 - `splash` — startup animation
+- `cursor_trail` — elastic trailing animation behind the pointer (spring-damper physics)
 
 Each plugin struct implements `effect_core::Effect` (purely visual) **and** exposes typed `pub` methods (`set_enabled`, `set_rects`, `click_at`, `dismiss`, `update`, …) that the host uses for control.
 
@@ -71,11 +72,12 @@ Standalone Wayland client binary. Anchors a `zwlr-layer-shell-v1` surface at the
 
 ## `chain_position` assignments
 
-| overlay    | position | rationale |
-|------------|----------|-----------|
-| `splash`   | 95       | Covers everything during startup |
-| `skeleton` | 85       | Debug overlay with labels |
-| `measure`  | 80       | Cursor measurement, visible when toggled |
+| overlay        | position | rationale |
+|----------------|----------|-----------|
+| `splash`       | 95       | Covers everything during startup |
+| `skeleton`     | 85       | Debug overlay with labels |
+| `measure`      | 80       | Cursor measurement, visible when toggled |
+| `cursor_trail` | 75       | Elastic trailing animation behind pointer |
 
 Effects with higher positions appear earlier in the custom-element Vec (which is the topmost slot in smithay's render stack).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "effect-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cosmic-text",
  "serde",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "effect-plugins"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cosmic-text",
  "effect-core",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "emskin"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bitflags 2.11.1",
  "clap",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "emskin-bar"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cosmic-text",
  "smithay-client-toolkit",

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ emskin [OPTIONS]
   --no-spawn              Don't start Emacs; wait for external connection
   --command <CMD>         Program to launch (default: "emacs")
   --arg <ARG>             Arguments for --command (repeatable)
-  --bar <MODE>            Workspace bar: "builtin" (default) or "none"
+  --bar <MODE>            Workspace bar: "auto" (default), "none", or a path
   --xkb-layout <LAYOUT>   Keyboard layout (e.g. "us", "cn")
 ```
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -95,6 +95,13 @@ M-x emskin-open-native-app RET foot
 - `C-x 5 o` — 切换工作区
 - `C-x 5 0` — 关闭当前工作区
 
+当存在两个及以上工作区时，顶部会自动出现一个工作区栏（`emskin-bar`），
+回到单工作区时自动消失。通过 `--bar=<模式>` 控制：
+
+- `--bar=auto` *(默认)* — 自动查找 `emskin-bar`
+- `--bar=none` — 不启动栏（如自行运行 waybar）
+- `--bar=/路径` — 使用自定义程序（任何支持 `zwlr-layer-shell-v1 + ext-workspace-v1` 的 bar）
+
 ### 使用启动器
 
 绑定快捷键启动 zofi / rofi 等启动器：
@@ -136,7 +143,7 @@ emskin [OPTIONS]
   --no-spawn              不启动 Emacs，等待外部连接
   --command <CMD>         启动命令 (默认: "emacs")
   --arg <ARG>             命令参数 (可多次指定)
-  --bar <MODE>            工作区栏: "builtin" (默认) 或 "none"
+  --bar <MODE>            工作区栏: "auto" (默认)、"none" 或自定义路径
   --xkb-layout <LAYOUT>   键盘布局 (例: "us", "cn")
 ```
 

--- a/crates/effect-plugins/CLAUDE.md
+++ b/crates/effect-plugins/CLAUDE.md
@@ -39,6 +39,13 @@ Startup animation (letters + underline bar). Dismissed when Emacs connects.
 - `impl Effect::post_paint` returns `!done` to drive continuous redraws during animation
 - `should_remove = done` — chain drops the plugin after animation finishes
 
+### `cursor_trail` — chain_position 75
+
+Elastic trailing animation: 10 spring-damped nodes follow the cursor in a chain. Stretches on fast movement, bounces back when stopped.
+
+- `pub fn set_enabled(bool)` — toggle (called from `IncomingMessage::SetCursorTrail`)
+- `impl Effect` reads `ctx.cursor_pos` + `ctx.present_time` to step physics; `post_paint` returns `!settled` to keep redrawing during settle
+
 The workspace bar used to live here. It was extracted into a standalone Wayland client (`crates/emskin-bar/`) that talks to the compositor via `zwlr-layer-shell-v1` + `ext-workspace-v1` — effect-plugins no longer carries workspace semantics.
 
 ## Canvas-only drawing
@@ -51,6 +58,7 @@ Every plugin paints **only within** `ctx.canvas` (an `Rectangle<i32, Logical>` e
 - `measure::is_active` = `self.enabled`
 - `skeleton::is_active` = `self.enabled`
 - `splash::is_active` = `!self.done`
+- `cursor_trail::is_active` = `self.enabled`
 
 ## Adding a new plugin
 

--- a/crates/effect-plugins/src/cursor_trail.rs
+++ b/crates/effect-plugins/src/cursor_trail.rs
@@ -211,7 +211,8 @@ impl effect_core::Effect for CursorTrail {
         let now = ctx.present_time;
         let dt = self
             .last_time
-            .map(|prev| (now - prev).as_secs_f64())
+            .and_then(|prev| now.checked_sub(prev))
+            .map(|d| d.as_secs_f64())
             .unwrap_or(0.0);
         self.last_time = Some(now);
 

--- a/crates/effect-plugins/src/cursor_trail.rs
+++ b/crates/effect-plugins/src/cursor_trail.rs
@@ -1,0 +1,271 @@
+//! Cursor trail — elastic trailing animation behind the pointer.
+//!
+//! A chain of "nodes" follows the cursor with spring-damper physics. Each
+//! node trails the one in front, producing an elastic tail. Fast cursor
+//! movement stretches the chain; when the cursor stops the nodes bounce
+//! back and settle.
+//!
+//! Visual: each node is a pre-rendered soft circle (anti-aliased, once at
+//! init), placed with decreasing size and opacity toward the tail.
+
+use std::time::Duration;
+
+use smithay::{
+    backend::{
+        allocator::Fourcc,
+        renderer::{
+            element::{
+                memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement},
+                Kind,
+            },
+            gles::GlesRenderer,
+            utils::CommitCounter,
+        },
+    },
+    utils::{Buffer, Logical, Physical, Point, Scale, Size, Transform},
+};
+
+use effect_core::paint_buffer;
+
+// ---------------------------------------------------------------------------
+// Physics tuning
+// ---------------------------------------------------------------------------
+
+const NODE_COUNT: usize = 10;
+/// Spring stiffness — higher = snappier return.
+const STIFFNESS: f64 = 120.0;
+/// Damping — higher = less oscillation. 12 keeps ~1 bounce before settling.
+const DAMPING: f64 = 12.0;
+/// Maximum delta-time per physics step (prevents explosion on frame hitches).
+const MAX_DT: f64 = 1.0 / 30.0;
+
+// ---------------------------------------------------------------------------
+// Visual tuning
+// ---------------------------------------------------------------------------
+
+/// Radius of the largest (head) circle, in logical pixels.
+const HEAD_RADIUS: i32 = 7;
+/// Radius of the smallest (tail) circle.
+const TAIL_RADIUS: i32 = 2;
+/// Alpha of the head node.
+const HEAD_ALPHA: f32 = 0.75;
+/// Alpha of the tail node.
+const TAIL_ALPHA: f32 = 0.12;
+/// Circle color: vivid magenta-pink (#FF4DA6 → BGRA).
+const CIRCLE_COLOR: [u8; 4] = [0xa6, 0x4d, 0xff, 0xff]; // BGRA
+
+// ---------------------------------------------------------------------------
+// Soft-circle texture
+// ---------------------------------------------------------------------------
+
+fn render_circle(radius: i32) -> (MemoryRenderBuffer, CommitCounter) {
+    let diameter = radius * 2 + 1;
+    let buf_size: Size<i32, Buffer> = (diameter, diameter).into();
+    let mut buf = MemoryRenderBuffer::new(Fourcc::Argb8888, (1, 1), 1, Transform::Normal, None);
+    let mut commit = CommitCounter::default();
+    paint_buffer(&mut buf, buf_size, |data| {
+        let cx = radius as f64;
+        let cy = radius as f64;
+        let r = radius as f64;
+        for py in 0..diameter {
+            for px in 0..diameter {
+                let dx = px as f64 - cx;
+                let dy = py as f64 - cy;
+                let dist = (dx * dx + dy * dy).sqrt();
+                let a = if dist <= r - 1.0 {
+                    1.0
+                } else if dist <= r {
+                    r - dist
+                } else {
+                    0.0
+                };
+                let off = ((py * diameter + px) * 4) as usize;
+                let alpha = (a * CIRCLE_COLOR[3] as f64) as u8;
+                data[off] = CIRCLE_COLOR[0];
+                data[off + 1] = CIRCLE_COLOR[1];
+                data[off + 2] = CIRCLE_COLOR[2];
+                data[off + 3] = alpha;
+            }
+        }
+    });
+    commit.increment();
+    (buf, commit)
+}
+
+// ---------------------------------------------------------------------------
+// Node — one bead on the elastic chain
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct Node {
+    pos: Point<f64, Logical>,
+    vel: Point<f64, Logical>,
+}
+
+impl Default for Node {
+    fn default() -> Self {
+        Self {
+            pos: Point::from((0.0, 0.0)),
+            vel: Point::from((0.0, 0.0)),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CursorTrail
+// ---------------------------------------------------------------------------
+
+pub struct CursorTrail {
+    enabled: bool,
+    nodes: Vec<Node>,
+    last_time: Option<Duration>,
+    circle_bufs: Vec<(MemoryRenderBuffer, CommitCounter)>,
+    settled: bool,
+}
+
+impl Default for CursorTrail {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CursorTrail {
+    pub fn new() -> Self {
+        let mut circle_bufs = Vec::with_capacity(NODE_COUNT);
+        for i in 0..NODE_COUNT {
+            let t = i as f64 / (NODE_COUNT - 1).max(1) as f64;
+            let r = HEAD_RADIUS as f64 * (1.0 - t) + TAIL_RADIUS as f64 * t;
+            circle_bufs.push(render_circle(r.round() as i32));
+        }
+
+        Self {
+            enabled: false,
+            nodes: vec![Node::default(); NODE_COUNT],
+            last_time: None,
+            circle_bufs,
+            settled: true,
+        }
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+        if !enabled {
+            self.last_time = None;
+            self.settled = true;
+        }
+    }
+
+    fn step_physics(&mut self, cursor: Point<f64, Logical>, dt: f64) {
+        let dt = dt.min(MAX_DT);
+
+        self.nodes[0].pos = cursor;
+        self.nodes[0].vel = Point::from((0.0, 0.0));
+
+        let mut any_moving = false;
+        for i in 1..NODE_COUNT {
+            let target = self.nodes[i - 1].pos;
+            let dx = self.nodes[i].pos.x - target.x;
+            let dy = self.nodes[i].pos.y - target.y;
+
+            let ax = -STIFFNESS * dx - DAMPING * self.nodes[i].vel.x;
+            let ay = -STIFFNESS * dy - DAMPING * self.nodes[i].vel.y;
+
+            self.nodes[i].vel.x += ax * dt;
+            self.nodes[i].vel.y += ay * dt;
+            self.nodes[i].pos.x += self.nodes[i].vel.x * dt;
+            self.nodes[i].pos.y += self.nodes[i].vel.y * dt;
+
+            let speed = self.nodes[i].vel.x.abs() + self.nodes[i].vel.y.abs();
+            let dist = dx.abs() + dy.abs();
+            if speed > 0.1 || dist > 0.5 {
+                any_moving = true;
+            }
+        }
+        self.settled = !any_moving;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Effect impl
+// ---------------------------------------------------------------------------
+
+impl effect_core::Effect for CursorTrail {
+    fn name(&self) -> &'static str {
+        "cursor_trail"
+    }
+
+    fn is_active(&self) -> bool {
+        self.enabled
+    }
+
+    fn chain_position(&self) -> u8 {
+        75
+    }
+
+    fn pre_paint(&mut self, ctx: &effect_core::EffectCtx) {
+        let Some(cursor) = ctx.cursor_pos else {
+            self.last_time = None;
+            return;
+        };
+
+        let now = ctx.present_time;
+        let dt = self
+            .last_time
+            .map(|prev| (now - prev).as_secs_f64())
+            .unwrap_or(0.0);
+        self.last_time = Some(now);
+
+        if dt <= 0.0 {
+            for node in &mut self.nodes {
+                node.pos = cursor;
+                node.vel = Point::from((0.0, 0.0));
+            }
+            self.settled = false;
+            return;
+        }
+
+        self.step_physics(cursor, dt);
+    }
+
+    fn paint(
+        &mut self,
+        renderer: &mut GlesRenderer,
+        ctx: &effect_core::EffectCtx,
+    ) -> Vec<effect_core::CustomElement<GlesRenderer>> {
+        if ctx.cursor_pos.is_none() || self.settled {
+            return Vec::new();
+        }
+
+        let s: Scale<f64> = Scale::from(ctx.scale);
+        let mut out = Vec::with_capacity(NODE_COUNT);
+
+        // Render tail → head so head elements are on top (earlier in vec = topmost).
+        for i in (1..NODE_COUNT).rev() {
+            let t = i as f64 / (NODE_COUNT - 1).max(1) as f64;
+            let alpha = HEAD_ALPHA * (1.0 - t as f32) + TAIL_ALPHA * t as f32;
+            let node = &self.nodes[i];
+            let (ref buf, _commit) = self.circle_bufs[i];
+            let r = HEAD_RADIUS as f64 * (1.0 - t) + TAIL_RADIUS as f64 * t;
+            let loc = Point::<f64, Logical>::from((node.pos.x - r, node.pos.y - r));
+            let phys_loc: Point<f64, Physical> = loc.to_physical(s);
+
+            if let Ok(elem) = MemoryRenderBufferRenderElement::from_buffer(
+                renderer,
+                phys_loc,
+                buf,
+                Some(alpha),
+                None,
+                None,
+                Kind::Unspecified,
+            ) {
+                out.push(effect_core::CustomElement::Label(elem));
+            }
+        }
+
+        out
+    }
+
+    fn post_paint(&mut self) -> bool {
+        !self.settled
+    }
+}

--- a/crates/effect-plugins/src/lib.rs
+++ b/crates/effect-plugins/src/lib.rs
@@ -15,6 +15,7 @@
 //! program (`crates/emskin-bar/`) that talks to the compositor via
 //! `zwlr-layer-shell-v1` + `ext-workspace-v1`.
 
+pub mod cursor_trail;
 pub mod measure;
 pub mod skeleton;
 pub mod splash;

--- a/crates/emskin/src/ipc/dispatch.rs
+++ b/crates/emskin/src/ipc/dispatch.rs
@@ -42,6 +42,10 @@ pub fn handle_ipc_message(state: &mut EmskinState, msg: IncomingMessage) {
             tracing::debug!("IPC set_measure enabled={enabled}");
             state.measure.borrow_mut().set_enabled(enabled);
         }
+        IncomingMessage::SetCursorTrail { enabled } => {
+            tracing::debug!("IPC set_cursor_trail enabled={enabled}");
+            state.cursor_trail.borrow_mut().set_enabled(enabled);
+        }
         IncomingMessage::SetSkeleton { enabled, rects } => {
             tracing::debug!("IPC set_skeleton enabled={enabled} rects={}", rects.len());
             let mut sk = state.skeleton.borrow_mut();

--- a/crates/emskin/src/ipc/messages.rs
+++ b/crates/emskin/src/ipc/messages.rs
@@ -270,6 +270,16 @@ mod tests {
     }
 
     #[test]
+    fn parses_set_cursor_trail() {
+        let json = r#"{"type":"set_cursor_trail","enabled":true}"#;
+        let msg: IncomingMessage = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            msg,
+            IncomingMessage::SetCursorTrail { enabled: true }
+        ));
+    }
+
+    #[test]
     fn parses_set_skeleton_with_rects() {
         let json = r#"{"type":"set_skeleton","enabled":true,"rects":[{"kind":"window","x":0,"y":0,"w":100,"h":50}]}"#;
         let msg: IncomingMessage = serde_json::from_str(json).unwrap();

--- a/crates/emskin/src/ipc/messages.rs
+++ b/crates/emskin/src/ipc/messages.rs
@@ -58,6 +58,10 @@ pub enum IncomingMessage {
     SetMeasure {
         enabled: bool,
     },
+    /// Enable/disable the cursor trail effect.
+    SetCursorTrail {
+        enabled: bool,
+    },
     /// Set (and enable/disable) the skeleton overlay (frame layout inspector).
     /// When `enabled` is false, `rects` is ignored and the overlay is cleared.
     SetSkeleton {

--- a/crates/emskin/src/state.rs
+++ b/crates/emskin/src/state.rs
@@ -208,6 +208,7 @@ pub struct EmskinState {
     pub measure: std::rc::Rc<std::cell::RefCell<effect_plugins::measure::MeasureOverlay>>,
     pub skeleton: std::rc::Rc<std::cell::RefCell<effect_plugins::skeleton::SkeletonOverlay>>,
     pub splash: std::rc::Rc<std::cell::RefCell<effect_plugins::splash::SplashScreen>>,
+    pub cursor_trail: std::rc::Rc<std::cell::RefCell<effect_plugins::cursor_trail::CursorTrail>>,
 
     /// Whether a skeleton label-click was swallowed — matching release must
     /// also be swallowed. Lives in the window manager, not the overlay.
@@ -291,6 +292,10 @@ impl EmskinState {
             &mut effect_chain,
             effect_plugins::measure::MeasureOverlay::new(),
         );
+        let cursor_trail = register_overlay(
+            &mut effect_chain,
+            effect_plugins::cursor_trail::CursorTrail::new(),
+        );
 
         Ok(Self {
             start_time,
@@ -355,6 +360,7 @@ impl EmskinState {
             measure,
             skeleton,
             splash,
+            cursor_trail,
             skeleton_click_absorbed: false,
             last_emacs_connected: false,
             cursor_status: CursorImageStatus::default_named(),

--- a/elisp/emskin.el
+++ b/elisp/emskin.el
@@ -119,6 +119,16 @@ Key: window-id.  Value: (SOURCE-WIN . ((VIEW-ID . EMACS-WIN) ...)).")
   (interactive)
   (customize-set-variable 'emskin-measure (not emskin-measure)))
 
+(defvar emskin--cursor-trail nil)
+
+(defun emskin-toggle-cursor-trail ()
+  "Toggle the cursor trail effect."
+  (interactive)
+  (setq emskin--cursor-trail (not emskin--cursor-trail))
+  (emskin--send `(("type" . "set_cursor_trail")
+                  ("enabled" . ,emskin--cursor-trail)))
+  (message "emskin: cursor trail %s" (if emskin--cursor-trail "ON" "OFF")))
+
 (defun emskin-open-app (app-name)
   "Launch embedded application APP-NAME (Python script in `emskin-demo-dir')."
   (interactive "sApp name: ")


### PR DESCRIPTION
## Summary
- New `cursor_trail` effect plugin: 10 spring-damped nodes follow the cursor, producing an elastic trailing animation that stretches on fast movement and bounces back when stopped
- Vivid magenta-pink circles with size/alpha gradient (7px→2px, α 0.75→0.12)
- Toggle via IPC `set_cursor_trail` or `M-x emskin-toggle-cursor-trail`
- Fix stale `--bar` CLI docs ("builtin" → "auto") in both READMEs
- Add workspace bar section to Chinese README (was missing)
- Update chain_position table and effect-plugins CLAUDE.md

## Test plan
- [ ] `cargo run`, then `M-x emskin-toggle-cursor-trail` — trail appears behind cursor
- [ ] Move cursor fast → trail stretches; stop → trail bounces back and settles
- [ ] Toggle off → trail disappears immediately
- [ ] Verify no render cost when disabled (`post_paint` returns false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)