### PR TITLE
fix: IME not working on startup without opening other apps first

### DIFF
--- a/crates/emskin/src/handlers/xdg_shell.rs
+++ b/crates/emskin/src/handlers/xdg_shell.rs
@@ -1,3 +1,5 @@
+use smithay::wayland::text_input::TextInputSeat;
+
 use smithay::{
     delegate_xdg_shell,
     desktop::{
@@ -57,6 +59,9 @@ impl XdgShellHandler for EmskinState {
             if let Some(keyboard) = self.seat.get_keyboard() {
                 keyboard.set_focus(self, Some(window.into()), serial);
             }
+            self.seat.text_input().set_focus(self.emacs_surface.clone());
+            self.seat.text_input().enter();
+            self.focus.pending_ime_allowed = Some(true);
         } else if self.is_emacs_client(surface.wl_surface()) {
             // Same Wayland client as Emacs — could be a new frame (C-x 5 2) or
             // a child frame (posframe, company-posframe, etc.).


### PR DESCRIPTION
When Emacs connects as a pgtk Wayland client, keyboard focus is granted in new_toplevel() but text_input focus and enter were never set. This caused smithay to discard all text_input requests from Emacs, making Chinese/IME input impossible until another app was opened and focus cycled.

Fix by calling text_input().set_focus() and enter() alongside keyboard.set_focus(), and overriding pending_ime_allowed to true so the host IME is not disabled by the SeatHandler before Emacs creates its text_input object.