### PR TITLE
fix(ime): debounce set_ime_allowed and widen enable condition

### DIFF
--- a/crates/emskin/src/handlers/mod.rs
+++ b/crates/emskin/src/handlers/mod.rs
@@ -77,15 +77,28 @@ impl SeatHandler for EmskinState {
         }
         self.focus.text_input_focus = new;
 
-        // Only enable host IME when the focused client has bound text_input_v3.
-        // Apps using their own IM module (fcitx5-gtk via DBus) don't bind it
-        // and need raw keyboard events from wl_keyboard instead.
-        let mut has_ti = false;
-        ti.with_focused_text_input(|_, _| {
-            has_ti = true;
-        });
-        if self.focus.pending_ime_allowed != Some(has_ti) {
-            self.focus.pending_ime_allowed = Some(has_ti);
+        // Request host IME whenever a surface holds focus; drop it only
+        // when focus becomes empty.
+        //
+        // The previous policy gated this on `with_focused_text_input` —
+        // i.e. only enable IME if the focused client had already bound
+        // zwp_text_input_v3. But `focus_changed` runs synchronously from
+        // `keyboard.set_focus`, before a freshly-connected client has had
+        // a roundtrip to bind text_input_v3, so the first focus transition
+        // latched `Some(false)` and Chinese/IME input stayed broken in
+        // pgtk Emacs until focus cycled through another app.
+        //
+        // Requesting IME for every focused surface is safe: clients that
+        // bind text_input_v3 receive preedit/commit via the bridge as
+        // before, and clients that don't bind it (GTK/Qt via fcitx5 DBus,
+        // gtk3 Emacs) have winit's `Ime` events silently dropped by the
+        // bridge — raw wl_keyboard events are unaffected.
+        //
+        // Debouncing lives in `winit::apply_pending_state` so repeat focus
+        // events don't spam `set_ime_allowed`.
+        let desired = self.focus.text_input_focus.is_some();
+        if self.focus.ime_currently_allowed != desired {
+            self.focus.pending_ime_allowed = Some(desired);
         }
     }
 }

--- a/crates/emskin/src/state.rs
+++ b/crates/emskin/src/state.rs
@@ -57,8 +57,14 @@ pub struct FocusState {
     /// Tracks text_input focus for manual enter/leave management. Kept as
     /// `WlSurface` because text_input_v3 is a Wayland-only protocol.
     pub text_input_focus: Option<WlSurface>,
-    /// Deferred `set_ime_allowed` for the winit window.
+    /// Deferred `set_ime_allowed` for the winit window. Consumed (`.take()`)
+    /// in `winit::apply_pending_state` each tick.
     pub pending_ime_allowed: Option<bool>,
+    /// Last value actually applied to `winit::set_ime_allowed`. Used to
+    /// debounce the apply step so we don't re-send `zwp_text_input_v3.enable`
+    /// to the host on every focus event — that can feed back through IME
+    /// traffic into more focus changes and thrash the protocol.
+    pub ime_currently_allowed: bool,
     /// Saved keyboard focus before a layer surface took it.
     pub layer_saved_focus: Option<crate::KeyboardFocusTarget>,
 }
@@ -713,7 +719,13 @@ impl EmskinState {
         self.focus.prefix_saved_focus = None;
         self.focus.layer_saved_focus = None;
         self.focus.text_input_focus = None;
-        self.focus.pending_ime_allowed = Some(false);
+        // NOTE: intentionally not touching `pending_ime_allowed` /
+        // `ime_currently_allowed` here. The subsequent `keyboard.set_focus`
+        // drives `focus_changed`, which re-requests the IME state based on
+        // whether the new focus is non-empty. Forcing `Some(false)` here
+        // pushed an extra `set_ime_allowed(false)` into the apply tick, which
+        // together with focus_changed's follow-up request caused a visible
+        // enable/disable oscillation under the host IME.
         // Reset skeleton state for the new workspace (window manager drives this,
         // not the effect trait).
         {

--- a/crates/emskin/src/winit.rs
+++ b/crates/emskin/src/winit.rs
@@ -57,7 +57,15 @@ fn apply_pending_state(state: &mut EmskinState, backend: &mut WinitGraphicsBacke
     }
 
     if let Some(allowed) = state.focus.pending_ime_allowed.take() {
-        backend.window().set_ime_allowed(allowed);
+        // Debounce: only cross the winit boundary when the value actually
+        // changes. Each `set_ime_allowed` call translates to a
+        // `zwp_text_input_v3.enable` / `disable` request to the host; repeat
+        // calls can feed back as IME events that trigger more focus changes
+        // and oscillate the IME state.
+        if state.focus.ime_currently_allowed != allowed {
+            backend.window().set_ime_allowed(allowed);
+            state.focus.ime_currently_allowed = allowed;
+        }
     }
 
     if state.cursor_changed {


### PR DESCRIPTION
Supersedes #40, #41. Fixes the IME startup latch **and** the
enable/disable oscillation that the naive \`Some(true)\` fix introduced.

## Two coupled bugs

### 1. Startup latch (original #40 symptom)

\`SeatHandler::focus_changed\` gated \`pending_ime_allowed\` on
\`with_focused_text_input\` — only enable host IME if the focused client
had already bound \`zwp_text_input_v3\`. But \`focus_changed\` runs
synchronously from \`keyboard.set_focus\`, before a freshly-connected
client has had a roundtrip to bind text_input_v3. First focus
transition latched \`Some(false)\`, \`apply_pending_state\` called
\`set_ime_allowed(false)\`, and Chinese/IME input stayed broken in pgtk
Emacs until focus cycled through another app.

### 2. Oscillation (the regression #41 caused)

\`pending_ime_allowed: Option<bool>\` is consumed by \`.take()\` each tick,
so an unconditional \`Some(true)\` in \`focus_changed\` re-applies on every
focus event. Each apply sends \`zwp_text_input_v3.enable\` to the host.
Combined with the explicit \`Some(false)\` reset in \`switch_workspace\`
(\`state.rs:716\`), host IME visibly ping-pongs between enabled and
disabled on every focus change.

## Fix

- **New field \`FocusState::ime_currently_allowed: bool\`** — canonical
  record of the last value actually crossed to \`winit::set_ime_allowed\`.
- **\`apply_pending_state\` debounces** — calls \`set_ime_allowed\` only
  when the requested value differs from \`ime_currently_allowed\`.
- **\`focus_changed\` widens the trigger** — \`desired =
  text_input_focus.is_some()\`, and only touches \`pending_ime_allowed\`
  when \`desired != ime_currently_allowed\`. This both fixes the startup
  latch and keeps the apply path idle in steady state.
- **Remove workspace-switch reset** — the subsequent \`keyboard.set_focus\`
  already drives \`focus_changed\`; the explicit \`Some(false)\` was
  fighting the debounce and re-introducing oscillation.

## Tradeoff

Requesting IME on any focused surface (not just text_input_v3 binders)
means host fcitx5 activates for GTK/Qt-via-DBus clients too. Their
\`Ime\` events are silently dropped by the bridge when no focused
text_input is bound; raw \`wl_keyboard\` events are unaffected. No
behavior change for users who rely on fcitx5-gtk via DBus inside an
embedded GTK app.

## Test plan

- [x] \`cargo check -p emskin\`
- [x] \`cargo clippy -p emskin --all-targets -- -D warnings\`
- [x] \`cargo fmt -p emskin --check\`
- [ ] Manual: cold-start emskin, first pgtk Emacs frame, trigger fcitx5
      (Ctrl+Space), type pinyin → Chinese input works immediately.
- [ ] Manual regression: Ctrl+Space repeatedly → no enable/disable
      oscillation (observe fcitx5 state indicator and \`RUST_LOG=trace\`
      for \`set_ime_allowed\` calls; expect at most one per focus edge).
- [ ] Manual regression: C-x 5 5 (switch workspace) repeatedly → IME
      stays in a single stable state per workspace.
- [ ] Manual regression: focus-cycle Emacs ↔ embedded GTK app → IME
      state stabilizes without flicker.

Closes #40.