### PR TITLE
chore: update Cargo.lock to match version 0.3.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "emskin"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "bitflags 2.11.1",
  "clap",


### PR DESCRIPTION
Commit fa0c7f0
用的旧版本，这里手动更新下。