### PR TITLE
refactor(state): complete #59 plan — effects/cursor/emacs + dissolve pending_*

### DIFF
--- a/crates/emskin/src/handlers/seat.rs
+++ b/crates/emskin/src/handlers/seat.rs
@@ -21,8 +21,7 @@ impl SeatHandler for EmskinState {
         _seat: &Seat<Self>,
         image: smithay::input::pointer::CursorImageStatus,
     ) {
-        self.cursor_status = image;
-        self.cursor_changed = true;
+        self.cursor.set_image(image);
         self.needs_redraw = true;
     }
 

--- a/crates/emskin/src/handlers/xdg_shell.rs
+++ b/crates/emskin/src/handlers/xdg_shell.rs
@@ -227,7 +227,7 @@ impl XdgShellHandler for EmskinState {
     fn fullscreen_request(&mut self, surface: ToplevelSurface, _output: Option<WlOutput>) {
         if self.is_emacs_surface(&surface) {
             tracing::info!("Emacs requested fullscreen");
-            self.pending_fullscreen = Some(true);
+            self.emacs.request_fullscreen(true);
             Self::set_toplevel_state(&surface, xdg_toplevel::State::Fullscreen, true);
         } else if self.apps.id_for_surface(surface.wl_surface()).is_some() {
             // Embedded app fullscreen: set state so the client hides its
@@ -250,7 +250,7 @@ impl XdgShellHandler for EmskinState {
     fn maximize_request(&mut self, surface: ToplevelSurface) {
         if self.is_emacs_surface(&surface) {
             tracing::info!("Emacs requested maximize");
-            self.pending_maximize = Some(true);
+            self.emacs.request_maximize(true);
             Self::set_toplevel_state(&surface, xdg_toplevel::State::Maximized, true);
         }
     }

--- a/crates/emskin/src/handlers/xdg_shell.rs
+++ b/crates/emskin/src/handlers/xdg_shell.rs
@@ -27,11 +27,11 @@ impl XdgShellHandler for EmskinState {
     }
 
     fn new_toplevel(&mut self, surface: ToplevelSurface) {
-        if self.detect_emacs && self.emacs_surface.is_none() && !self.initial_size_settled {
+        if self.emacs.should_claim_main() {
             // First toplevel = Emacs (Wayland/pgtk path only).
             // X11 Emacs sets initial_size_settled in map_window_request.
             tracing::info!("Emacs toplevel connected");
-            self.emacs_surface = Some(surface.wl_surface().clone());
+            self.emacs.set_surface(Some(surface.wl_surface().clone()));
 
             if let Some(output) = self.workspace.active_space.outputs().next() {
                 if let Some(mode) = output.current_mode() {
@@ -47,7 +47,7 @@ impl XdgShellHandler for EmskinState {
                     });
                 }
             }
-            self.initial_size_settled = true;
+            self.emacs.mark_size_settled();
 
             let window = Window::new_wayland_window(surface);
             self.workspace
@@ -267,7 +267,7 @@ impl XdgShellHandler for EmskinState {
             if let Some(title) = title {
                 tracing::debug!("Emacs title changed: {title}");
                 self.workspace.active_name = extract_bar_name(&title);
-                self.emacs_title = Some(title);
+                self.emacs.set_title(title);
             }
         } else if self.is_any_emacs_surface(surface.wl_surface()) {
             // Inactive workspace Emacs frame — update its workspace name.
@@ -298,7 +298,7 @@ impl XdgShellHandler for EmskinState {
                 Self::get_toplevel_data(&surface, |d| d.lock().ok().and_then(|d| d.app_id.clone()));
             if let Some(app_id) = app_id {
                 tracing::debug!("Emacs app_id changed: {}", app_id);
-                self.emacs_app_id = Some(app_id);
+                self.emacs.set_app_id(app_id);
             }
         }
         // Inactive workspace Emacs or other surfaces: ignore app_id changes.
@@ -392,7 +392,7 @@ pub fn handle_surface_commit(
 
 impl EmskinState {
     fn is_emacs_surface(&self, surface: &ToplevelSurface) -> bool {
-        Some(surface.wl_surface()) == self.emacs_surface.as_ref()
+        self.emacs.is_main_surface(surface.wl_surface())
     }
 
     fn set_toplevel_state(surface: &ToplevelSurface, state: xdg_toplevel::State, enabled: bool) {

--- a/crates/emskin/src/input.rs
+++ b/crates/emskin/src/input.rs
@@ -8,7 +8,7 @@ use smithay::{
         pointer::{AxisFrame, ButtonEvent, MotionEvent, RelativeMotionEvent},
     },
     reexports::wayland_server::Resource,
-    utils::{Point, SERIAL_COUNTER},
+    utils::SERIAL_COUNTER,
     wayland::{
         pointer_constraints::{with_pointer_constraint, PointerConstraint},
         seat::WaylandFocus,
@@ -99,10 +99,7 @@ impl EmskinState {
                 // zwp_relative_pointer_v1 — independent of
                 // `pointer.current_location()`, which freezes under a
                 // pointer lock while clients still need raw delta.
-                let delta = match self.last_pointer_raw_loc.replace(new_abs) {
-                    Some(prev) => new_abs - prev,
-                    None => Point::default(),
-                };
+                let delta = self.cursor.consume_raw_location(new_abs);
                 let time_msec = event.time_msec();
                 let new_under = self.surface_under(new_abs);
 

--- a/crates/emskin/src/input.rs
+++ b/crates/emskin/src/input.rs
@@ -44,7 +44,7 @@ impl EmskinState {
 
                         if pressed && !is_modifier_keysym(key) {
                             if let Some(label) = format_chord(modifiers, key) {
-                                state.key_cast.borrow_mut().push(label);
+                                state.effects.key_cast.borrow_mut().push(label);
                             }
                         }
 
@@ -260,16 +260,16 @@ impl EmskinState {
                     // Scope the borrow so subsequent pointer-focus code can
                     // still reborrow `self`.
                     let skeleton_hit = {
-                        let mut sk = self.skeleton.borrow_mut();
+                        let mut sk = self.effects.skeleton.borrow_mut();
                         sk.enabled() && sk.click_at(pos).is_some()
                     };
                     if skeleton_hit {
-                        self.skeleton_click_absorbed = true;
+                        self.effects.skeleton_click_absorbed = true;
                         return;
                     }
                 }
-                if button_state == ButtonState::Released && self.skeleton_click_absorbed {
-                    self.skeleton_click_absorbed = false;
+                if button_state == ButtonState::Released && self.effects.skeleton_click_absorbed {
+                    self.effects.skeleton_click_absorbed = false;
                     return;
                 }
 

--- a/crates/emskin/src/ipc/dispatch.rs
+++ b/crates/emskin/src/ipc/dispatch.rs
@@ -40,19 +40,19 @@ pub fn handle_ipc_message(state: &mut EmskinState, msg: IncomingMessage) {
         }
         IncomingMessage::SetMeasure { enabled } => {
             tracing::debug!("IPC set_measure enabled={enabled}");
-            state.measure.borrow_mut().set_enabled(enabled);
+            state.effects.measure.borrow_mut().set_enabled(enabled);
         }
         IncomingMessage::SetCursorTrail { enabled } => {
             tracing::debug!("IPC set_cursor_trail enabled={enabled}");
-            state.cursor_trail.borrow_mut().set_enabled(enabled);
+            state.effects.cursor_trail.borrow_mut().set_enabled(enabled);
         }
         IncomingMessage::SetKeyCast { enabled } => {
             tracing::debug!("IPC set_key_cast enabled={enabled}");
-            state.key_cast.borrow_mut().set_enabled(enabled);
+            state.effects.key_cast.borrow_mut().set_enabled(enabled);
         }
         IncomingMessage::SetSkeleton { enabled, rects } => {
             tracing::debug!("IPC set_skeleton enabled={enabled} rects={}", rects.len());
-            let mut sk = state.skeleton.borrow_mut();
+            let mut sk = state.effects.skeleton.borrow_mut();
             sk.set_enabled(enabled);
             if enabled {
                 sk.set_rects(rects);
@@ -68,7 +68,7 @@ pub fn handle_ipc_message(state: &mut EmskinState, msg: IncomingMessage) {
         }
         IncomingMessage::SetJellyCursor { enabled } => {
             tracing::debug!("IPC set_jelly_cursor enabled={enabled}");
-            state.jelly_cursor.borrow_mut().set_enabled(enabled);
+            state.effects.jelly_cursor.borrow_mut().set_enabled(enabled);
         }
         IncomingMessage::SetCursorRect { rect, color } => {
             ipc_set_cursor_rect(state, rect, color);
@@ -119,7 +119,7 @@ pub fn handle_ipc_message(state: &mut EmskinState, msg: IncomingMessage) {
 fn ipc_set_cursor_rect(state: &mut EmskinState, rect: crate::ipc::IpcRect, color: Option<String>) {
     let now = state.start_time.elapsed();
     let canvas_rect = state.emacs_rect_to_canvas(rect);
-    let mut jc = state.jelly_cursor.borrow_mut();
+    let mut jc = state.effects.jelly_cursor.borrow_mut();
     if let Some(hex) = color.as_deref() {
         jc.set_color_hex(hex);
     }

--- a/crates/emskin/src/lib.rs
+++ b/crates/emskin/src/lib.rs
@@ -14,5 +14,5 @@ pub mod xwayland_satellite;
 // Re-export state sub-modules at crate root so existing
 // `crate::apps::*`, `crate::focus::*`, `crate::ime::*`,
 // `crate::workspace::*` paths keep resolving.
-pub use state::{apps, cursor, effects, emacs, focus, ime, workspace};
+pub use state::{apps, cursor, effects, emacs, focus, ime, workspace, xwayland};
 pub use state::{EmskinState, KeyboardFocusTarget};

--- a/crates/emskin/src/lib.rs
+++ b/crates/emskin/src/lib.rs
@@ -14,5 +14,5 @@ pub mod xwayland_satellite;
 // Re-export state sub-modules at crate root so existing
 // `crate::apps::*`, `crate::focus::*`, `crate::ime::*`,
 // `crate::workspace::*` paths keep resolving.
-pub use state::{apps, effects, focus, ime, workspace};
+pub use state::{apps, cursor, effects, focus, ime, workspace};
 pub use state::{EmskinState, KeyboardFocusTarget};

--- a/crates/emskin/src/lib.rs
+++ b/crates/emskin/src/lib.rs
@@ -14,5 +14,5 @@ pub mod xwayland_satellite;
 // Re-export state sub-modules at crate root so existing
 // `crate::apps::*`, `crate::focus::*`, `crate::ime::*`,
 // `crate::workspace::*` paths keep resolving.
-pub use state::{apps, cursor, effects, focus, ime, workspace};
+pub use state::{apps, cursor, effects, emacs, focus, ime, workspace};
 pub use state::{EmskinState, KeyboardFocusTarget};

--- a/crates/emskin/src/lib.rs
+++ b/crates/emskin/src/lib.rs
@@ -14,5 +14,5 @@ pub mod xwayland_satellite;
 // Re-export state sub-modules at crate root so existing
 // `crate::apps::*`, `crate::focus::*`, `crate::ime::*`,
 // `crate::workspace::*` paths keep resolving.
-pub use state::{apps, focus, ime, workspace};
+pub use state::{apps, effects, focus, ime, workspace};
 pub use state::{EmskinState, KeyboardFocusTarget};

--- a/crates/emskin/src/main.rs
+++ b/crates/emskin/src/main.rs
@@ -177,7 +177,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if !cli.no_spawn {
-        state.pending_command = Some(state::PendingCommand {
+        state.xwayland.set_pending_command(state::PendingCommand {
             command: cli.command.clone(),
             args: cli.command_args.clone(),
             standalone: cli.standalone,
@@ -287,11 +287,9 @@ fn spawn_child(
         .env("DISPLAY", format!(":{x_display}"))
         // Ensure child apps prefer Wayland even when host is X11.
         .env("XDG_SESSION_TYPE", "wayland")
-        .env("GDK_BACKEND", "wayland,x11")
-        .env("QT_QPA_PLATFORM", "wayland;xcb")
-        .env("SDL_VIDEODRIVER", "wayland")
-        .env("CLUTTER_BACKEND", "wayland")
         .env("XDG_SESSION_DESKTOP", "emskin")
+        // .env("GTK_IM_MODULE","wayland")
+        // .env("QT_IM_MODULE","wayland")
         .spawn()
     {
         Ok(child) => state.emacs.set_child(child),
@@ -455,14 +453,16 @@ fn start_xwayland_satellite(
     };
 
     let (tx, rx) = channel::channel::<ToMain>();
-    state.xwls = Some(XwlsIntegration::new(sockets, spawn_cfg, tx));
+    state
+        .xwayland
+        .set_integration(XwlsIntegration::new(sockets, spawn_cfg, tx));
 
     // Rearm handler: when the spawner thread reports child exit, drain
     // pending connections and re-install the socket watch.
     let rearm_handle = handle.clone();
     if let Err(e) = handle.insert_source(rx, move |event, _, st| {
         if let channel::Event::Msg(ToMain::Rearm) = event {
-            if let Some(x) = st.xwls.as_mut() {
+            if let Some(x) = st.xwayland.integration_mut() {
                 if let Err(e) = x.on_rearm(&rearm_handle) {
                     tracing::warn!("xwayland-satellite rearm failed: {e}");
                 }
@@ -470,27 +470,32 @@ fn start_xwayland_satellite(
         }
     }) {
         tracing::error!("xwayland-satellite: failed to install rearm channel: {e}");
-        state.xwls = None;
+        state.xwayland.clear_integration();
         return;
     }
 
-    if let Err(e) = state.xwls.as_mut().unwrap().arm(&handle) {
+    if let Err(e) = state
+        .xwayland
+        .integration_mut()
+        .expect("set_integration above guarantees Some")
+        .arm(&handle)
+    {
         tracing::error!("xwayland-satellite: arm() failed: {e}");
-        state.xwls = None;
+        state.xwayland.clear_integration();
         return;
     }
 
     // Socket is ready — export DISPLAY and notify Emacs. First X client
     // connect will trigger the on-demand satellite spawn automatically.
     std::env::set_var("DISPLAY", &display_name);
-    state.xdisplay = Some(display);
+    state.xwayland.set_display(display);
     state
         .ipc
         .send(ipc::OutgoingMessage::XWaylandReady { display });
     tracing::info!("xwayland-satellite: socket ready on {display_name}");
 
     // Spawn pending Emacs now that both WAYLAND_DISPLAY and DISPLAY are set.
-    if let Some(pc) = state.pending_command.take() {
+    if let Some(pc) = state.xwayland.take_pending_command() {
         spawn_child(&pc.command, &pc.args, display, pc.standalone, state);
     }
 }

--- a/crates/emskin/src/main.rs
+++ b/crates/emskin/src/main.rs
@@ -199,7 +199,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     event_loop.run(None, &mut state, emskin::tick::event_loop_tick)?;
 
     // Clean up Emacs child process
-    if let Some(mut child) = state.emacs_child.take() {
+    if let Some(mut child) = state.emacs.take_child() {
         let _ = child.kill();
         let _ = child.wait();
     }
@@ -294,7 +294,7 @@ fn spawn_child(
         .env("XDG_SESSION_DESKTOP", "emskin")
         .spawn()
     {
-        Ok(child) => state.emacs_child = Some(child),
+        Ok(child) => state.emacs.set_child(child),
         Err(e) => tracing::error!("Failed to spawn '{command}': {e}"),
     }
 }

--- a/crates/emskin/src/state/cursor.rs
+++ b/crates/emskin/src/state/cursor.rs
@@ -1,0 +1,253 @@
+//! Cursor image tracking + relative-pointer delta synthesis.
+//!
+//! Two unrelated concerns live here because both flow through the same
+//! pipe (host winit → compositor → embedded clients) and both are
+//! driven by the pointer:
+//!
+//! 1. **Image** (`status` + `changed`). Clients set cursors via
+//!    `wp_cursor_shape_v1` (Named, forwarded to winit's `CursorIcon`)
+//!    or `wl_pointer.set_cursor` with a Surface argument (GTK3 /
+//!    Emacs — software-rendered each frame because winit cannot
+//!    forward arbitrary buffers to the host). The `changed` flag is
+//!    drained by the render loop in the next frame.
+//!
+//! 2. **Raw pointer tracking** (`last_raw_loc`). smithay's winit
+//!    backend only emits `PointerMotionAbsolute` — there is no
+//!    raw-motion source — so `zwp_relative_pointer_v1` (required by
+//!    Minecraft, Blender, browser Pointer Lock) is synthesised by
+//!    diffing consecutive host-reported absolutes. This delta stays
+//!    correct under a pointer lock, while `pointer.current_location()`
+//!    would freeze.
+
+use smithay::input::pointer::CursorImageStatus;
+use smithay::reexports::wayland_server::Resource;
+use smithay::utils::{Logical, Point};
+
+pub struct CursorState {
+    status: CursorImageStatus,
+    /// Set when `status` changes; cleared by the render loop in the
+    /// frame that applies the change to the host winit window.
+    changed: bool,
+    /// Last raw absolute pointer location from the host, in compositor
+    /// coords. `None` on first event.
+    last_raw_loc: Option<Point<f64, Logical>>,
+}
+
+impl Default for CursorState {
+    fn default() -> Self {
+        Self {
+            status: CursorImageStatus::default_named(),
+            changed: false,
+            last_raw_loc: None,
+        }
+    }
+}
+
+impl CursorState {
+    /// Replace the cursor image and mark it dirty. Called from
+    /// `SeatHandler::cursor_image` whenever a client updates its
+    /// cursor via wp_cursor_shape_v1 or wl_pointer.set_cursor.
+    pub fn set_image(&mut self, image: CursorImageStatus) {
+        self.status = image;
+        self.changed = true;
+    }
+
+    /// Peek at the current image without touching the dirty flag.
+    /// Used by the software cursor path in the render loop, which
+    /// draws every frame regardless of whether the image changed.
+    pub fn status(&self) -> &CursorImageStatus {
+        &self.status
+    }
+
+    /// Drain the dirty flag. `Some(&status)` means the host winit
+    /// window should update `set_cursor` / `set_cursor_visible`
+    /// this frame; `None` means no change pending.
+    pub fn take_changed(&mut self) -> Option<&CursorImageStatus> {
+        if self.changed {
+            self.changed = false;
+            Some(&self.status)
+        } else {
+            None
+        }
+    }
+
+    /// If the currently set Surface cursor has been destroyed by its
+    /// client, fall back to the default named cursor. Called once per
+    /// render frame before the software-cursor walk — otherwise the
+    /// render path would chase a dead `WlSurface`.
+    pub fn ensure_alive(&mut self) {
+        if let CursorImageStatus::Surface(ref s) = self.status {
+            if !s.is_alive() {
+                self.status = CursorImageStatus::default_named();
+                self.changed = true;
+            }
+        }
+    }
+
+    /// On workspace switch, drop any Surface cursor that referenced
+    /// the departing workspace's clients so it isn't left rendering
+    /// against a stale surface tree. Named cursors survive — they're
+    /// owned by the host, not the clients.
+    pub fn reset_on_workspace_switch(&mut self) {
+        if matches!(self.status, CursorImageStatus::Surface(_)) {
+            self.status = CursorImageStatus::default_named();
+            self.changed = true;
+        }
+    }
+
+    /// Absorb a new raw absolute pointer location and return the
+    /// delta from the previous one (zero on first call). Drives
+    /// `zwp_relative_pointer_v1`.
+    pub fn consume_raw_location(&mut self, new_abs: Point<f64, Logical>) -> Point<f64, Logical> {
+        match self.last_raw_loc.replace(new_abs) {
+            Some(prev) => new_abs - prev,
+            None => Point::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smithay::reexports::winit::window::CursorIcon;
+
+    // Surface-path tests (ensure_alive with a dead surface,
+    // reset_on_workspace_switch dropping a Surface) require a live
+    // Wayland `Display` + `Client` to instantiate a `WlSurface`, which
+    // exceeds the scope of unit tests. Those paths are exercised by the
+    // e2e suite under `tests/e2e_*.rs`.
+
+    #[test]
+    fn default_is_named_not_changed_no_last_loc() {
+        let c = CursorState::default();
+        assert!(matches!(c.status, CursorImageStatus::Named(_)));
+        assert!(!c.changed);
+        assert!(c.last_raw_loc.is_none());
+    }
+
+    #[test]
+    fn status_returns_current_without_touching_changed() {
+        let c = CursorState::default();
+        let _ = c.status();
+        assert!(!c.changed, "read-only peek must not dirty the flag");
+    }
+
+    #[test]
+    fn set_image_writes_status_and_marks_changed() {
+        let mut c = CursorState::default();
+        c.set_image(CursorImageStatus::Hidden);
+        assert!(matches!(c.status, CursorImageStatus::Hidden));
+        assert!(c.changed);
+    }
+
+    #[test]
+    fn set_image_named_overrides_default_named() {
+        let mut c = CursorState::default();
+        c.set_image(CursorImageStatus::Named(CursorIcon::Crosshair));
+        assert!(
+            matches!(c.status, CursorImageStatus::Named(CursorIcon::Crosshair)),
+            "set_image did not replace the Named variant"
+        );
+        assert!(c.changed);
+    }
+
+    #[test]
+    fn take_changed_returns_none_when_clean() {
+        let mut c = CursorState::default();
+        assert!(c.take_changed().is_none());
+        assert!(!c.changed);
+    }
+
+    #[test]
+    fn take_changed_returns_some_once_then_clears() {
+        let mut c = CursorState::default();
+        c.set_image(CursorImageStatus::Hidden);
+        {
+            let drained = c.take_changed().expect("first drain returns Some");
+            assert!(matches!(drained, CursorImageStatus::Hidden));
+        }
+        assert!(
+            !c.changed,
+            "take_changed must clear the dirty flag after handing out the value"
+        );
+        assert!(c.take_changed().is_none());
+    }
+
+    #[test]
+    fn ensure_alive_is_no_op_on_named() {
+        let mut c = CursorState::default();
+        c.ensure_alive();
+        assert!(matches!(c.status, CursorImageStatus::Named(_)));
+        assert!(
+            !c.changed,
+            "ensure_alive must not dirty when status is not Surface"
+        );
+    }
+
+    #[test]
+    fn ensure_alive_is_no_op_on_hidden() {
+        let mut c = CursorState::default();
+        c.set_image(CursorImageStatus::Hidden);
+        let _ = c.take_changed();
+        c.ensure_alive();
+        assert!(matches!(c.status, CursorImageStatus::Hidden));
+        assert!(!c.changed);
+    }
+
+    #[test]
+    fn reset_on_workspace_switch_is_no_op_on_named() {
+        let mut c = CursorState::default();
+        c.reset_on_workspace_switch();
+        assert!(matches!(c.status, CursorImageStatus::Named(_)));
+        assert!(
+            !c.changed,
+            "reset must not dirty when nothing was torn down"
+        );
+    }
+
+    #[test]
+    fn reset_on_workspace_switch_is_no_op_on_hidden() {
+        let mut c = CursorState::default();
+        c.set_image(CursorImageStatus::Hidden);
+        let _ = c.take_changed();
+        c.reset_on_workspace_switch();
+        assert!(matches!(c.status, CursorImageStatus::Hidden));
+        assert!(!c.changed);
+    }
+
+    #[test]
+    fn consume_raw_location_first_call_returns_zero() {
+        let mut c = CursorState::default();
+        let delta = c.consume_raw_location((10.0, 20.0).into());
+        assert_eq!(delta, Point::<f64, Logical>::from((0.0, 0.0)));
+    }
+
+    #[test]
+    fn consume_raw_location_returns_delta_after_first() {
+        let mut c = CursorState::default();
+        let _ = c.consume_raw_location((10.0, 20.0).into());
+        let delta = c.consume_raw_location((30.0, 25.0).into());
+        assert_eq!(delta, Point::<f64, Logical>::from((20.0, 5.0)));
+    }
+
+    #[test]
+    fn consume_raw_location_updates_last_for_subsequent_calls() {
+        let mut c = CursorState::default();
+        let _ = c.consume_raw_location((10.0, 20.0).into());
+        let _ = c.consume_raw_location((30.0, 25.0).into());
+        let delta = c.consume_raw_location((35.0, 30.0).into());
+        assert_eq!(
+            delta,
+            Point::<f64, Logical>::from((5.0, 5.0)),
+            "third call must diff against the second, not the first"
+        );
+    }
+
+    #[test]
+    fn consume_raw_location_handles_negative_delta() {
+        let mut c = CursorState::default();
+        let _ = c.consume_raw_location((50.0, 50.0).into());
+        let delta = c.consume_raw_location((30.0, 40.0).into());
+        assert_eq!(delta, Point::<f64, Logical>::from((-20.0, -10.0)));
+    }
+}

--- a/crates/emskin/src/state/effects.rs
+++ b/crates/emskin/src/state/effects.rs
@@ -1,0 +1,112 @@
+//! Built-in visual overlays and their window-manager-side bookkeeping.
+//!
+//! Each overlay is owned as `Rc<RefCell<T>>` and registered into
+//! `chain` through `effect_core::EffectHandle`, which keeps a clone of
+//! the same `Rc`. That lets the window manager call typed setters
+//! (`set_enabled`, `set_rects`, `click_at`, …) directly while the
+//! render loop iterates the trait-erased chain — see
+//! `../../effect-plugins/CLAUDE.md` for the plugin-side half of this
+//! contract.
+//!
+//! The three `*_click_absorbed` / `last_*` flags are **not** effect
+//! state: they are edge-detect latches kept on the host so a pure
+//! `Effect` never has to peek at higher-level state (IPC connection,
+//! recorder state machine, …). Grouping them with the handles keeps
+//! the whole "overlays" concern in one place.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use effect_core::{EffectChain, EffectHandle};
+use effect_plugins::{
+    cursor_trail::CursorTrail, jelly_cursor::JellyCursor, key_cast::KeyCastOverlay,
+    measure::MeasureOverlay, recorder::RecorderOverlay, skeleton::SkeletonOverlay,
+    splash::SplashScreen,
+};
+
+pub struct EffectsState {
+    /// Trait-erased render order. Iterated by the winit render loop via
+    /// `effect_core::render_workspace`.
+    pub chain: EffectChain,
+
+    // --- Typed handles. Same instance as the entry in `chain`. ---
+    pub measure: Rc<RefCell<MeasureOverlay>>,
+    pub skeleton: Rc<RefCell<SkeletonOverlay>>,
+    pub splash: Rc<RefCell<SplashScreen>>,
+    pub cursor_trail: Rc<RefCell<CursorTrail>>,
+    pub jelly_cursor: Rc<RefCell<JellyCursor>>,
+    pub recorder_overlay: Rc<RefCell<RecorderOverlay>>,
+    pub key_cast: Rc<RefCell<KeyCastOverlay>>,
+
+    // --- Edge-detect latches owned by the host. ---
+    /// A skeleton label-click was swallowed on press; the matching
+    /// release must also be swallowed so the underlying surface never
+    /// sees a lone `Released` without its `Pressed`.
+    pub skeleton_click_absorbed: bool,
+
+    /// `true` once Emacs's surface has appeared. Flipping `false → true`
+    /// fires `splash.dismiss()` exactly once.
+    pub last_emacs_connected: bool,
+
+    /// Mirrors `recorder.is_recording()` from the previous frame. Flip
+    /// toggles `key_cast` so screencasts always show keystrokes without
+    /// the user having to enable it separately.
+    pub last_recording_active: bool,
+}
+
+impl Default for EffectsState {
+    fn default() -> Self {
+        let mut chain = EffectChain::default();
+        // Render order is the registration order: splash sits above
+        // skeleton/measure (drawn later = on top). Do not reorder
+        // without checking `effect-plugins/CLAUDE.md`'s chain_position
+        // table.
+        let splash = register(&mut chain, SplashScreen::new());
+        let skeleton = register(&mut chain, SkeletonOverlay::new());
+        let measure = register(&mut chain, MeasureOverlay::new());
+        let cursor_trail = register(&mut chain, CursorTrail::new());
+        let jelly_cursor = register(&mut chain, JellyCursor::new());
+        let recorder_overlay = register(&mut chain, RecorderOverlay::new());
+        let key_cast = register(&mut chain, KeyCastOverlay::new());
+
+        Self {
+            chain,
+            measure,
+            skeleton,
+            splash,
+            cursor_trail,
+            jelly_cursor,
+            recorder_overlay,
+            key_cast,
+            skeleton_click_absorbed: false,
+            last_emacs_connected: false,
+            last_recording_active: false,
+        }
+    }
+}
+
+impl EffectsState {
+    /// Clear per-workspace visual state on workspace switch. The caller
+    /// passes the current elapsed time so the jelly overlay can reset
+    /// its caret tracking without animating from the departing
+    /// workspace's last known position.
+    pub fn reset_on_workspace_switch(&mut self, now: std::time::Duration) {
+        let mut sk = self.skeleton.borrow_mut();
+        sk.set_enabled(false);
+        sk.clear();
+        drop(sk);
+        self.skeleton_click_absorbed = false;
+        // Fresh `SetCursorRect` IPC messages will arrive from the new
+        // workspace's Emacs once focus stabilises.
+        self.jelly_cursor.borrow_mut().update(None, now);
+    }
+}
+
+/// Register an overlay into the chain and return a typed handle to the
+/// same instance. Private — construction of overlays is an
+/// implementation detail of `EffectsState::default`.
+fn register<T: effect_core::Effect + 'static>(chain: &mut EffectChain, value: T) -> Rc<RefCell<T>> {
+    let rc = Rc::new(RefCell::new(value));
+    chain.register(EffectHandle::new(rc.clone()));
+    rc
+}

--- a/crates/emskin/src/state/emacs.rs
+++ b/crates/emskin/src/state/emacs.rs
@@ -28,6 +28,14 @@ pub struct EmacsState {
     app_id: Option<String>,
     detect: bool,
     initial_size_settled: bool,
+    /// Deferred `set_fullscreen` request — produced by
+    /// `xdg_toplevel.set_fullscreen` on the Emacs surface, drained by
+    /// `apply_pending_state` on the next render tick. The CLI
+    /// `--fullscreen` startup flag piggybacks on the same mailbox.
+    pending_fullscreen: Option<bool>,
+    /// Deferred `set_maximized` request — mirror of
+    /// `pending_fullscreen` for the maximize toplevel state.
+    pending_maximize: Option<bool>,
 }
 
 impl EmacsState {
@@ -43,6 +51,8 @@ impl EmacsState {
             app_id: None,
             detect,
             initial_size_settled: false,
+            pending_fullscreen: None,
+            pending_maximize: None,
         }
     }
 
@@ -112,6 +122,27 @@ impl EmacsState {
     /// currently write-only.
     pub fn set_app_id(&mut self, app_id: String) {
         self.app_id = Some(app_id);
+    }
+
+    // -- Pending host-window-state requests -------------------------
+
+    /// Request the host winit window enter/leave fullscreen. Drained
+    /// by `apply_pending_state` in the next render tick.
+    pub fn request_fullscreen(&mut self, fullscreen: bool) {
+        self.pending_fullscreen = Some(fullscreen);
+    }
+
+    pub fn take_pending_fullscreen(&mut self) -> Option<bool> {
+        self.pending_fullscreen.take()
+    }
+
+    /// Request the host winit window enter/leave maximize.
+    pub fn request_maximize(&mut self, maximize: bool) {
+        self.pending_maximize = Some(maximize);
+    }
+
+    pub fn take_pending_maximize(&mut self) -> Option<bool> {
+        self.pending_maximize.take()
     }
 
     // -- Lifecycle latches ------------------------------------------
@@ -334,5 +365,75 @@ mod tests {
         let mut e = EmacsState::new(true);
         e.mark_size_settled();
         assert!(!e.main_died());
+    }
+
+    // -- pending_fullscreen / pending_maximize ----------------------
+
+    #[test]
+    fn pending_fullscreen_empty_by_default() {
+        let mut e = EmacsState::new(true);
+        assert!(e.take_pending_fullscreen().is_none());
+    }
+
+    #[test]
+    fn request_fullscreen_true_roundtrips_via_take() {
+        let mut e = EmacsState::new(true);
+        e.request_fullscreen(true);
+        assert_eq!(e.take_pending_fullscreen(), Some(true));
+        assert!(
+            e.take_pending_fullscreen().is_none(),
+            "take drains — a second read returns None"
+        );
+    }
+
+    #[test]
+    fn request_fullscreen_false_roundtrips_via_take() {
+        let mut e = EmacsState::new(true);
+        e.request_fullscreen(false);
+        assert_eq!(e.take_pending_fullscreen(), Some(false));
+    }
+
+    #[test]
+    fn request_fullscreen_overwrites_previous_pending_value() {
+        // If two requests arrive before the render tick drains, the
+        // later one wins — that matches the existing flat-assignment
+        // semantics (`state.pending_fullscreen = Some(true)` etc.).
+        let mut e = EmacsState::new(true);
+        e.request_fullscreen(false);
+        e.request_fullscreen(true);
+        assert_eq!(e.take_pending_fullscreen(), Some(true));
+    }
+
+    #[test]
+    fn pending_maximize_empty_by_default() {
+        let mut e = EmacsState::new(true);
+        assert!(e.take_pending_maximize().is_none());
+    }
+
+    #[test]
+    fn request_maximize_true_roundtrips_via_take() {
+        let mut e = EmacsState::new(true);
+        e.request_maximize(true);
+        assert_eq!(e.take_pending_maximize(), Some(true));
+        assert!(e.take_pending_maximize().is_none());
+    }
+
+    #[test]
+    fn request_maximize_overwrites_previous_pending_value() {
+        let mut e = EmacsState::new(true);
+        e.request_maximize(false);
+        e.request_maximize(true);
+        assert_eq!(e.take_pending_maximize(), Some(true));
+    }
+
+    #[test]
+    fn pending_fullscreen_and_maximize_are_independent() {
+        // Setting one must not drain or contaminate the other.
+        let mut e = EmacsState::new(true);
+        e.request_fullscreen(true);
+        assert!(e.take_pending_maximize().is_none());
+        e.request_maximize(false);
+        assert_eq!(e.take_pending_fullscreen(), Some(true));
+        assert_eq!(e.take_pending_maximize(), Some(false));
     }
 }

--- a/crates/emskin/src/state/emacs.rs
+++ b/crates/emskin/src/state/emacs.rs
@@ -1,0 +1,338 @@
+//! Emacs host-process state — the main surface, the spawned `emacs`
+//! child, title / app-id metadata forwarded to the host toplevel, and
+//! the two latches (`detect`, `initial_size_settled`) that encode the
+//! "first toplevel == Emacs" heuristic and the associated end-of-life
+//! detection.
+//!
+//! The detection heuristic exists because emskin deliberately does not
+//! run a separate bootstrap handshake with Emacs — the first
+//! `xdg_toplevel` that maps is claimed as the main surface, the frame
+//! is resized to cover the host window, and the initial configure is
+//! acked. After that latch, subsequent toplevels are plain embedded
+//! apps. This is disabled via `EMSKIN_DISABLE_EMACS_DETECTION=1` for
+//! e2e tests that spawn transient Wayland clients (wl-copy, xclip …)
+//! without a real Emacs ever attaching — otherwise the first test
+//! client would be mis-tagged as Emacs and its exit would trip the
+//! "last Emacs died → shutdown" path.
+
+use smithay::reexports::wayland_server::{protocol::wl_surface::WlSurface, Resource};
+
+pub struct EmacsState {
+    surface: Option<WlSurface>,
+    child: Option<std::process::Child>,
+    title: Option<String>,
+    /// Currently write-only — stored on `xdg_toplevel.set_app_id`
+    /// but never forwarded. Kept on the struct so the wire-level
+    /// handler has somewhere to park the value; retiring it is a
+    /// separate decision.
+    app_id: Option<String>,
+    detect: bool,
+    initial_size_settled: bool,
+}
+
+impl EmacsState {
+    /// Construct with detection toggled from the `EMSKIN_DISABLE_EMACS_DETECTION`
+    /// env var (absent → `true`; present → `false`). The caller reads
+    /// the env itself so tests can construct `EmacsState { detect:
+    /// false, .. }` without touching the process environment.
+    pub fn new(detect: bool) -> Self {
+        Self {
+            surface: None,
+            child: None,
+            title: None,
+            app_id: None,
+            detect,
+            initial_size_settled: false,
+        }
+    }
+
+    // -- Main surface ------------------------------------------------
+
+    /// The main Emacs surface, or `None` if unset. Stable across the
+    /// lifetime of an Emacs instance — reassigned only on workspace
+    /// switch (which swaps in a different workspace's Emacs surface).
+    pub fn surface(&self) -> Option<&WlSurface> {
+        self.surface.as_ref()
+    }
+
+    /// Assign the main surface. Overwrites any prior value.
+    pub fn set_surface(&mut self, surface: Option<WlSurface>) {
+        self.surface = surface;
+    }
+
+    /// Remove and return the main surface. Used by workspace-switch
+    /// to hand the current Emacs frame over to the inactive workspace
+    /// store before loading the incoming workspace's surface.
+    pub fn take_surface(&mut self) -> Option<WlSurface> {
+        self.surface.take()
+    }
+
+    /// True when `candidate` is the current main Emacs surface.
+    pub fn is_main_surface(&self, candidate: &WlSurface) -> bool {
+        self.surface.as_ref() == Some(candidate)
+    }
+
+    /// True when the main-surface slot is set.
+    pub fn has_main_surface(&self) -> bool {
+        self.surface.is_some()
+    }
+
+    // -- Process handle ---------------------------------------------
+
+    /// Stash the spawned `emacs` child so the shutdown path can reap
+    /// it and the tick loop can poll liveness.
+    pub fn set_child(&mut self, child: std::process::Child) {
+        self.child = Some(child);
+    }
+
+    /// Remove and return the child handle (shutdown path).
+    pub fn take_child(&mut self) -> Option<std::process::Child> {
+        self.child.take()
+    }
+
+    /// Mutable access to the child, for `try_wait` polling.
+    pub fn child_mut(&mut self) -> Option<&mut std::process::Child> {
+        self.child.as_mut()
+    }
+
+    // -- Title / app_id metadata ------------------------------------
+
+    /// Record an Emacs-supplied window title. The render loop drains
+    /// it via `take_title` once per frame to forward to the host
+    /// winit window.
+    pub fn set_title(&mut self, title: String) {
+        self.title = Some(title);
+    }
+
+    pub fn take_title(&mut self) -> Option<String> {
+        self.title.take()
+    }
+
+    /// Record an Emacs-supplied app_id. See struct field note —
+    /// currently write-only.
+    pub fn set_app_id(&mut self, app_id: String) {
+        self.app_id = Some(app_id);
+    }
+
+    // -- Lifecycle latches ------------------------------------------
+
+    /// Flip once the first `initial_configure` reply from Emacs has
+    /// arrived, sizing the main surface to the host window.
+    pub fn mark_size_settled(&mut self) {
+        self.initial_size_settled = true;
+    }
+
+    /// Whether the main-frame size-settle event has happened. Gates
+    /// host `Resized` → Emacs propagation and the shutdown check.
+    pub fn size_settled(&self) -> bool {
+        self.initial_size_settled
+    }
+
+    pub fn detection_enabled(&self) -> bool {
+        self.detect
+    }
+
+    // -- Composite predicates that encapsulate the detection rules --
+
+    /// A new `xdg_toplevel` should be claimed as the main Emacs
+    /// surface: detection is on, nothing has been claimed yet, and
+    /// the size-settle latch has not fired.
+    pub fn should_claim_main(&self) -> bool {
+        self.detect && self.surface.is_none() && !self.initial_size_settled
+    }
+
+    /// The main Emacs surface has died after having been established
+    /// (i.e. `initial_size_settled` was reached) — the compositor
+    /// should shut down. Detection-off means never shut down via this
+    /// path; that mirrors the intent of `EMSKIN_DISABLE_EMACS_DETECTION`
+    /// for tests that don't want a dying wl-copy to kill the harness.
+    pub fn main_died(&self) -> bool {
+        self.detect
+            && self.initial_size_settled
+            && self.surface.as_ref().is_some_and(|s| !s.is_alive())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `WlSurface` requires a live Display + Client to instantiate, so
+    // all surface-related predicates (`is_main_surface`, the live/dead
+    // branch of `main_died`, the `set_surface(Some(..))` path) are
+    // covered by the e2e suite — only the `None` / default-false
+    // branches are exercised here. Everything else (child, title,
+    // app_id, latches, composite predicates with surface=None) is
+    // pure logic and fair game.
+
+    fn short_lived_child() -> std::process::Child {
+        // `true` exits successfully with no output; the test asserts
+        // presence/handover of the `Child` handle itself, not runtime
+        // behavior.
+        std::process::Command::new("true")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn /bin/true for test")
+    }
+
+    #[test]
+    fn new_with_detection_on_initialises_empty_and_unsettled() {
+        let e = EmacsState::new(true);
+        assert!(e.surface().is_none());
+        assert!(!e.has_main_surface());
+        assert!(!e.size_settled());
+        assert!(e.detection_enabled());
+        // No child, no title, no app_id right after construction.
+        assert!(e.title.is_none());
+        assert!(e.app_id.is_none());
+    }
+
+    #[test]
+    fn new_with_detection_off_disables_detection_flag() {
+        let e = EmacsState::new(false);
+        assert!(!e.detection_enabled());
+        // Other fields still default.
+        assert!(e.surface().is_none());
+        assert!(!e.size_settled());
+    }
+
+    #[test]
+    fn set_surface_none_is_idempotent_from_default() {
+        let mut e = EmacsState::new(true);
+        e.set_surface(None);
+        assert!(e.surface().is_none());
+        assert!(!e.has_main_surface());
+    }
+
+    #[test]
+    fn take_surface_from_empty_returns_none() {
+        let mut e = EmacsState::new(true);
+        assert!(e.take_surface().is_none());
+    }
+
+    #[test]
+    fn set_and_take_child_handoff() {
+        let mut e = EmacsState::new(true);
+        assert!(e.child_mut().is_none());
+
+        e.set_child(short_lived_child());
+        assert!(e.child_mut().is_some(), "set_child must store the handle");
+
+        let mut taken = e.take_child().expect("take_child returns what was set");
+        assert!(e.take_child().is_none(), "take_child must clear the slot");
+        // Reap so the test doesn't leave a zombie if `true` hasn't
+        // been polled yet.
+        let _ = taken.wait();
+    }
+
+    #[test]
+    fn set_child_overwrites_previous_without_panic() {
+        let mut e = EmacsState::new(true);
+        e.set_child(short_lived_child());
+        e.set_child(short_lived_child());
+        // Both handles end up in the slot sequentially; we only care
+        // that the second call doesn't panic and leaves a handle.
+        let mut taken = e.take_child().expect("second set_child took effect");
+        let _ = taken.wait();
+    }
+
+    #[test]
+    fn title_set_then_take() {
+        let mut e = EmacsState::new(true);
+        assert!(e.take_title().is_none());
+
+        e.set_title("GNU Emacs".into());
+        assert_eq!(e.take_title().as_deref(), Some("GNU Emacs"));
+        assert!(
+            e.take_title().is_none(),
+            "take drains — second read returns None"
+        );
+    }
+
+    #[test]
+    fn title_set_overwrites_previous() {
+        let mut e = EmacsState::new(true);
+        e.set_title("old".into());
+        e.set_title("new".into());
+        assert_eq!(e.take_title().as_deref(), Some("new"));
+    }
+
+    #[test]
+    fn app_id_stored_but_not_readable_publicly() {
+        // The struct's field note says app_id is write-only at the
+        // public API level. The test asserts via the private field
+        // that `set_app_id` writes through.
+        let mut e = EmacsState::new(true);
+        e.set_app_id("emacs".into());
+        assert_eq!(e.app_id.as_deref(), Some("emacs"));
+        e.set_app_id("Emacs".into());
+        assert_eq!(
+            e.app_id.as_deref(),
+            Some("Emacs"),
+            "set_app_id overwrites previous value"
+        );
+    }
+
+    #[test]
+    fn mark_size_settled_flips_latch() {
+        let mut e = EmacsState::new(true);
+        assert!(!e.size_settled());
+        e.mark_size_settled();
+        assert!(e.size_settled());
+        // Idempotent.
+        e.mark_size_settled();
+        assert!(e.size_settled());
+    }
+
+    #[test]
+    fn should_claim_main_true_initially_when_detection_on() {
+        let e = EmacsState::new(true);
+        assert!(e.should_claim_main());
+    }
+
+    #[test]
+    fn should_claim_main_false_when_detection_off() {
+        let e = EmacsState::new(false);
+        assert!(!e.should_claim_main());
+    }
+
+    #[test]
+    fn should_claim_main_false_once_size_settled() {
+        let mut e = EmacsState::new(true);
+        e.mark_size_settled();
+        assert!(
+            !e.should_claim_main(),
+            "claim window closes after initial size settles"
+        );
+    }
+
+    #[test]
+    fn main_died_false_when_detection_off() {
+        let mut e = EmacsState::new(false);
+        // Even if we forced size_settled and cleared the surface, the
+        // detection-off shortcut keeps this false so the harness
+        // doesn't shut down on transient clients dying.
+        e.mark_size_settled();
+        assert!(!e.main_died());
+    }
+
+    #[test]
+    fn main_died_false_before_initial_size_settled() {
+        let e = EmacsState::new(true);
+        // No surface ever set, size-settle never fired — not a "died"
+        // condition (Emacs never mapped in the first place).
+        assert!(!e.main_died());
+    }
+
+    #[test]
+    fn main_died_false_when_surface_absent_even_after_settle() {
+        // This guards against a bug where clearing the surface via
+        // workspace-switch would trip main_died. main_died's Surface
+        // branch is e2e-covered; this test asserts the surface=None
+        // branch returns false regardless of size_settled.
+        let mut e = EmacsState::new(true);
+        e.mark_size_settled();
+        assert!(!e.main_died());
+    }
+}

--- a/crates/emskin/src/state/mod.rs
+++ b/crates/emskin/src/state/mod.rs
@@ -5,6 +5,7 @@ pub mod emacs;
 pub mod focus;
 pub mod ime;
 pub mod workspace;
+pub mod xwayland;
 
 // Type re-exports for common shorthands (kept for historical call sites
 // that used `crate::KeyboardFocusTarget` before state/ existed).
@@ -130,11 +131,9 @@ pub struct WaylandState {
     pub popups: PopupManager,
 }
 
-pub struct PendingCommand {
-    pub command: String,
-    pub args: Vec<String>,
-    pub standalone: bool,
-}
+/// Re-export so pre-extraction call sites (main.rs spawning the
+/// `--command` child) keep compiling without qualifying the path.
+pub use xwayland::PendingCommand;
 
 pub struct EmskinState {
     pub start_time: std::time::Instant,
@@ -157,19 +156,17 @@ pub struct EmskinState {
     // Smithay protocol state (grouped for clarity).
     pub wl: WaylandState,
 
-    // XWayland: `xwls` owns the pre-bound X11 sockets and lazily
-    // spawns an external `xwayland-satellite` process on X client
-    // connect. `xdisplay` caches the `:N` number for convenience
-    // (exported as DISPLAY, sent to Emacs via IPC).
-    pub xdisplay: Option<u32>,
-    pub xwls: Option<crate::xwayland_satellite::XwlsIntegration>,
+    /// XWayland supervisor state — display number, xwayland-satellite
+    /// integration handle, and the `--command` deferred-spawn mailbox.
+    pub xwayland: xwayland::XwaylandState,
 
     pub seat: Seat<Self>,
 
     // --- emskin specific ---
     /// Emacs host-process state — main surface, child process, title /
-    /// app_id metadata, detection and size-settle latches. Centralises
-    /// the "first toplevel == Emacs" heuristic.
+    /// app_id metadata, detection and size-settle latches, plus the
+    /// `request_fullscreen` / `request_maximize` mailboxes the Emacs
+    /// toplevel populates via `xdg_toplevel.set_fullscreen` etc.
     pub emacs: emacs::EmacsState,
 
     /// Handle to the spawned emskin-bar process (None = `--bar=none` or the
@@ -178,16 +175,6 @@ pub struct EmskinState {
 
     /// Path to extracted elisp dir (for cleanup on exit).
     pub elisp_dir: Option<std::path::PathBuf>,
-
-    /// Pending fullscreen request to forward to host window.
-    /// Some(true) = request fullscreen, Some(false) = exit fullscreen
-    pub pending_fullscreen: Option<bool>,
-
-    /// Pending maximize request to forward to host window.
-    pub pending_maximize: Option<bool>,
-
-    /// Child command to spawn once XWayland is ready (None = already spawned or --no-spawn).
-    pub pending_command: Option<PendingCommand>,
 
     /// Clipboard/selection routing state.
     pub selection: SelectionState,
@@ -314,8 +301,7 @@ impl EmskinState {
                 relative_pointer_manager_state,
                 popups,
             },
-            xdisplay: None,
-            xwls: None,
+            xwayland: xwayland::XwaylandState::default(),
             seat,
 
             // emskin specific
@@ -324,9 +310,6 @@ impl EmskinState {
             ),
             bar_child: None,
             elisp_dir: None,
-            pending_fullscreen: None,
-            pending_maximize: None,
-            pending_command: None,
             selection: SelectionState::default(),
             focus: FocusState::default(),
             ime,
@@ -746,7 +729,7 @@ impl EmskinState {
 
 impl crate::xwayland_satellite::HasXwls for EmskinState {
     fn xwls_mut(&mut self) -> Option<&mut crate::xwayland_satellite::XwlsIntegration> {
-        self.xwls.as_mut()
+        self.xwayland.integration_mut()
     }
 }
 

--- a/crates/emskin/src/state/mod.rs
+++ b/crates/emskin/src/state/mod.rs
@@ -1,4 +1,5 @@
 pub mod apps;
+pub mod cursor;
 pub mod effects;
 pub mod focus;
 pub mod ime;
@@ -13,7 +14,7 @@ use std::{collections::HashMap, ffi::OsString, sync::Arc};
 use smithay::{
     backend::{renderer::gles::GlesRenderer, winit::WinitGraphicsBackend},
     desktop::{PopupManager, Space, Window, WindowSurfaceType},
-    input::{pointer::CursorImageStatus, Seat, SeatState},
+    input::{Seat, SeatState},
     reexports::{
         calloop::{
             generic::Generic, EventLoop, Interest, LoopHandle, LoopSignal, Mode, PostAction,
@@ -220,18 +221,9 @@ pub struct EmskinState {
     /// a single cohesive module instead of eleven flat fields.
     pub effects: effects::EffectsState,
 
-    /// Current cursor image status. For Named, the host cursor is used;
-    /// for Surface (GTK3/Emacs), the cursor is software-rendered each frame.
-    pub cursor_status: CursorImageStatus,
-    /// Set when cursor_status changes; consumed by apply_pending_state.
-    pub cursor_changed: bool,
-
-    /// Last raw absolute pointer location from the host, in compositor
-    /// coords. Used to synthesize relative-motion deltas for
-    /// `zwp_relative_pointer_v1` (required by FPS games) — the winit
-    /// backend only emits absolute positions, so we diff consecutive
-    /// absolutes to produce the delta. `None` on first event.
-    pub last_pointer_raw_loc: Option<Point<f64, Logical>>,
+    /// Cursor image tracking (Named / Surface) + raw pointer location
+    /// for `zwp_relative_pointer_v1` delta synthesis.
+    pub cursor: cursor::CursorState,
 
     /// Coarse damage flag for structural events (IPC, layer shell, input,
     /// workspace switch) that smithay's per-element OutputDamageTracker does
@@ -360,9 +352,7 @@ impl EmskinState {
             focus: FocusState::default(),
             ime,
             effects: effects::EffectsState::default(),
-            cursor_status: CursorImageStatus::default_named(),
-            cursor_changed: false,
-            last_pointer_raw_loc: None,
+            cursor: cursor::CursorState::default(),
             needs_redraw: true,
             recorder: crate::recording::Recorder::new(),
         })
@@ -626,10 +616,7 @@ impl EmskinState {
         self.effects
             .reset_on_workspace_switch(self.start_time.elapsed());
 
-        if matches!(self.cursor_status, CursorImageStatus::Surface(_)) {
-            self.cursor_status = CursorImageStatus::default_named();
-            self.cursor_changed = true;
-        }
+        self.cursor.reset_on_workspace_switch();
 
         // Notify Emacs BEFORE changing keyboard focus. IPC is flushed
         // immediately (same syscall), while wl_keyboard.enter is buffered

--- a/crates/emskin/src/state/mod.rs
+++ b/crates/emskin/src/state/mod.rs
@@ -1,6 +1,7 @@
 pub mod apps;
 pub mod cursor;
 pub mod effects;
+pub mod emacs;
 pub mod focus;
 pub mod ime;
 pub mod workspace;
@@ -166,23 +167,10 @@ pub struct EmskinState {
     pub seat: Seat<Self>,
 
     // --- emskin specific ---
-    /// The Emacs surface (first toplevel to connect)
-    pub emacs_surface: Option<WlSurface>,
-
-    /// Whether the initial size has been configured.
-    /// Set to true once Emacs receives the host window size in its first configure.
-    /// After this, host Resized events propagate size to Emacs.
-    pub initial_size_settled: bool,
-
-    /// When false, skip the "first toplevel == Emacs" heuristic and the
-    /// "last Emacs frame died → stop" shutdown path. Set from the
-    /// `EMSKIN_DISABLE_EMACS_DETECTION` env var at startup; intended
-    /// for E2E tests that spawn transient Wayland clients (wl-copy,
-    /// xclip, …) without a real Emacs ever attaching.
-    pub detect_emacs: bool,
-
-    /// Handle to the spawned Emacs process
-    pub emacs_child: Option<std::process::Child>,
+    /// Emacs host-process state — main surface, child process, title /
+    /// app_id metadata, detection and size-settle latches. Centralises
+    /// the "first toplevel == Emacs" heuristic.
+    pub emacs: emacs::EmacsState,
 
     /// Handle to the spawned emskin-bar process (None = `--bar=none` or the
     /// binary couldn't be located). Kept alive so it's reaped on shutdown.
@@ -197,12 +185,6 @@ pub struct EmskinState {
 
     /// Pending maximize request to forward to host window.
     pub pending_maximize: Option<bool>,
-
-    /// Emacs window title, forwarded to host toplevel
-    pub emacs_title: Option<String>,
-
-    /// Emacs app_id, forwarded to host toplevel
-    pub emacs_app_id: Option<String>,
 
     /// Child command to spawn once XWayland is ready (None = already spawned or --no-spawn).
     pub pending_command: Option<PendingCommand>,
@@ -337,16 +319,13 @@ impl EmskinState {
             seat,
 
             // emskin specific
-            emacs_surface: None,
-            initial_size_settled: false,
-            detect_emacs: std::env::var_os("EMSKIN_DISABLE_EMACS_DETECTION").is_none(),
-            emacs_child: None,
+            emacs: emacs::EmacsState::new(
+                std::env::var_os("EMSKIN_DISABLE_EMACS_DETECTION").is_none(),
+            ),
             bar_child: None,
             elisp_dir: None,
             pending_fullscreen: None,
             pending_maximize: None,
-            emacs_title: None,
-            emacs_app_id: None,
             pending_command: None,
             selection: SelectionState::default(),
             focus: FocusState::default(),
@@ -461,7 +440,7 @@ impl EmskinState {
     /// including gtk3 Emacs over XWayland — presents as a Wayland
     /// toplevel, so there is no separate X11 branch.
     pub fn emacs_window(&self) -> Option<Window> {
-        let surface = self.emacs_surface.as_ref()?;
+        let surface = self.emacs.surface()?;
         self.workspace
             .active_space
             .elements()
@@ -561,14 +540,14 @@ impl EmskinState {
 
     /// Check if a surface belongs to the same Wayland client as the active Emacs.
     pub fn is_emacs_client(&self, surface: &WlSurface) -> bool {
-        self.emacs_surface
-            .as_ref()
+        self.emacs
+            .surface()
             .is_some_and(|emacs| emacs.same_client_as(&surface.id()))
     }
 
     /// Check if a surface is any workspace's Emacs surface (active or inactive).
     pub fn is_any_emacs_surface(&self, surface: &WlSurface) -> bool {
-        if self.emacs_surface.as_ref() == Some(surface) {
+        if self.emacs.is_main_surface(surface) {
             return true;
         }
         self.workspace
@@ -589,7 +568,7 @@ impl EmskinState {
 
         // Swap: current active → inactive, target → active.
         let old_space = std::mem::take(&mut self.workspace.active_space);
-        let old_emacs = self.emacs_surface.take();
+        let old_emacs = self.emacs.take_surface();
         let old_name = std::mem::take(&mut self.workspace.active_name);
         self.workspace.inactive.insert(
             self.workspace.active_id,
@@ -601,7 +580,7 @@ impl EmskinState {
         );
 
         self.workspace.active_space = target.space;
-        self.emacs_surface = target.emacs_surface.take();
+        self.emacs.set_surface(target.emacs_surface.take());
         self.workspace.active_name = target.name;
         self.workspace.active_id = target_id;
 
@@ -789,7 +768,7 @@ impl EmskinState {
         );
 
         // Active workspace's Emacs surface lives in self.workspace.active_space.
-        let active_emacs = self.emacs_surface.clone();
+        let active_emacs = self.emacs.surface().cloned();
         resize_emacs_in_space(&mut self.workspace.active_space, &active_emacs, geo);
 
         // Inactive workspaces each hold their own space + Emacs.

--- a/crates/emskin/src/state/mod.rs
+++ b/crates/emskin/src/state/mod.rs
@@ -1,4 +1,5 @@
 pub mod apps;
+pub mod effects;
 pub mod focus;
 pub mod ime;
 pub mod workspace;
@@ -214,35 +215,10 @@ pub struct EmskinState {
     /// IME (text_input_v3) bridge — host IME ↔ embedded Wayland clients.
     pub ime: crate::ime::ImeBridge,
 
-    /// Registered overlays driven by effect-core's `EffectChain`.
-    pub effect_chain: effect_core::EffectChain,
-
-    /// Typed handles to each overlay — same instance is also registered in
-    /// `effect_chain` via `EffectHandle`. Lets window-manager code (input
-    /// routing, IPC dispatch, workspace-switch reset) call the overlay's
-    /// typed setters directly without going through the trait.
-    pub measure: std::rc::Rc<std::cell::RefCell<effect_plugins::measure::MeasureOverlay>>,
-    pub skeleton: std::rc::Rc<std::cell::RefCell<effect_plugins::skeleton::SkeletonOverlay>>,
-    pub splash: std::rc::Rc<std::cell::RefCell<effect_plugins::splash::SplashScreen>>,
-    pub cursor_trail: std::rc::Rc<std::cell::RefCell<effect_plugins::cursor_trail::CursorTrail>>,
-    pub jelly_cursor: std::rc::Rc<std::cell::RefCell<effect_plugins::jelly_cursor::JellyCursor>>,
-    pub recorder_overlay:
-        std::rc::Rc<std::cell::RefCell<effect_plugins::recorder::RecorderOverlay>>,
-    pub key_cast: std::rc::Rc<std::cell::RefCell<effect_plugins::key_cast::KeyCastOverlay>>,
-
-    /// Whether a skeleton label-click was swallowed — matching release must
-    /// also be swallowed. Lives in the window manager, not the overlay.
-    pub skeleton_click_absorbed: bool,
-
-    /// Edge-detect latch for "Emacs just connected" → triggers `splash.dismiss()`
-    /// exactly once. Initialised false; set to true the first frame Emacs's
-    /// surface is present.
-    pub last_emacs_connected: bool,
-
-    /// Edge-detect latch for "recording state changed" → toggles
-    /// `key_cast` overlay on/off so screencasts always show keystrokes
-    /// without the user having to enable it separately.
-    pub last_recording_active: bool,
+    /// Built-in visual overlays + their host-side edge-detect flags.
+    /// Grouped so the render loop and workspace-switch reset both see
+    /// a single cohesive module instead of eleven flat fields.
+    pub effects: effects::EffectsState,
 
     /// Current cursor image status. For Named, the host cursor is used;
     /// for Surface (GTK3/Emacs), the cursor is software-rendered each frame.
@@ -320,40 +296,6 @@ impl EmskinState {
 
         let loop_signal = event_loop.get_signal();
 
-        // Overlays: same instance shared between the typed handle kept on
-        // `EmskinState` (for input routing, IPC dispatch, workspace-switch
-        // reset) and the `EffectHandle` wrapper registered into the chain
-        // (for rendering). `register_overlay` does both in one step.
-        let mut effect_chain = effect_core::EffectChain::default();
-        let splash = register_overlay(
-            &mut effect_chain,
-            effect_plugins::splash::SplashScreen::new(),
-        );
-        let skeleton = register_overlay(
-            &mut effect_chain,
-            effect_plugins::skeleton::SkeletonOverlay::new(),
-        );
-        let measure = register_overlay(
-            &mut effect_chain,
-            effect_plugins::measure::MeasureOverlay::new(),
-        );
-        let cursor_trail = register_overlay(
-            &mut effect_chain,
-            effect_plugins::cursor_trail::CursorTrail::new(),
-        );
-        let jelly_cursor = register_overlay(
-            &mut effect_chain,
-            effect_plugins::jelly_cursor::JellyCursor::new(),
-        );
-        let recorder_overlay = register_overlay(
-            &mut effect_chain,
-            effect_plugins::recorder::RecorderOverlay::new(),
-        );
-        let key_cast = register_overlay(
-            &mut effect_chain,
-            effect_plugins::key_cast::KeyCastOverlay::new(),
-        );
-
         Ok(Self {
             start_time,
             display_handle: dh,
@@ -417,17 +359,7 @@ impl EmskinState {
             selection: SelectionState::default(),
             focus: FocusState::default(),
             ime,
-            effect_chain,
-            measure,
-            skeleton,
-            splash,
-            cursor_trail,
-            jelly_cursor,
-            recorder_overlay,
-            key_cast,
-            skeleton_click_absorbed: false,
-            last_emacs_connected: false,
-            last_recording_active: false,
+            effects: effects::EffectsState::default(),
             cursor_status: CursorImageStatus::default_named(),
             cursor_changed: false,
             last_pointer_raw_loc: None,
@@ -691,20 +623,8 @@ impl EmskinState {
         self.focus.prefix_saved_focus = None;
         self.focus.layer_saved_focus = None;
         self.ime.reset_on_workspace_switch();
-        // Reset skeleton state for the new workspace (window manager drives this,
-        // not the effect trait).
-        {
-            let mut sk = self.skeleton.borrow_mut();
-            sk.set_enabled(false);
-            sk.clear();
-        }
-        self.skeleton_click_absorbed = false;
-        // Reset caret tracking so the jelly overlay doesn't animate from
-        // the previous workspace's caret position to the new one. The
-        // new workspace's Emacs will send fresh SetCursorRect messages
-        // after focus stabilizes.
-        let now = self.start_time.elapsed();
-        self.jelly_cursor.borrow_mut().update(None, now);
+        self.effects
+            .reset_on_workspace_switch(self.start_time.elapsed());
 
         if matches!(self.cursor_status, CursorImageStatus::Surface(_)) {
             self.cursor_status = CursorImageStatus::default_named();
@@ -944,15 +864,4 @@ pub struct ClientState {
 impl ClientData for ClientState {
     fn initialized(&self, _client_id: ClientId) {}
     fn disconnected(&self, _client_id: ClientId, _reason: DisconnectReason) {}
-}
-
-/// Register an overlay into the chain and return a typed handle to the same
-/// instance. Lets `EmskinState::new` construct each overlay with one line.
-fn register_overlay<T: effect_core::Effect + 'static>(
-    chain: &mut effect_core::EffectChain,
-    value: T,
-) -> std::rc::Rc<std::cell::RefCell<T>> {
-    let rc = std::rc::Rc::new(std::cell::RefCell::new(value));
-    chain.register(effect_core::EffectHandle::new(rc.clone()));
-    rc
 }

--- a/crates/emskin/src/state/xwayland.rs
+++ b/crates/emskin/src/state/xwayland.rs
@@ -1,0 +1,203 @@
+//! XWayland integration state — mirrors cosmic-comp's `XWaylandState`
+//! in shape (single-struct home for everything XWayland-related) even
+//! though it's much thinner because emskin delegates the actual X
+//! server to `xwayland-satellite` rather than running `Xwayland` under
+//! smithay's `X11Wm`.
+//!
+//! Three orthogonal pieces live here.
+//!
+//! **Display number** (`display`): cached `:N` for convenience —
+//! exported as `DISPLAY` to the Emacs child and sent to elisp via
+//! `XWaylandReady` IPC. Set once and forgotten.
+//!
+//! **Supervisor** (`integration`): pre-binds `/tmp/.X11-unix/X<N>` +
+//! the abstract socket, arms calloop watches, and lazily spawns
+//! `xwayland-satellite` on first X client connect. See the
+//! `crate::xwayland_satellite` module for the state machine.
+//!
+//! **Pending child command** (`pending_command`): the `--command`
+//! flag's value, parked until XWayland reports Ready so GTK3 /
+//! Electron children spawn with a valid `DISPLAY` in env. Drained
+//! exactly once by the main-loop hook that observes
+//! `xwayland_satellite::ToMain::Ready`.
+
+use crate::xwayland_satellite::XwlsIntegration;
+
+/// Child command to spawn once XWayland is ready. None = already
+/// spawned or `--no-spawn` was passed.
+pub struct PendingCommand {
+    pub command: String,
+    pub args: Vec<String>,
+    pub standalone: bool,
+}
+
+#[derive(Default)]
+pub struct XwaylandState {
+    display: Option<u32>,
+    integration: Option<XwlsIntegration>,
+    pending_command: Option<PendingCommand>,
+}
+
+impl XwaylandState {
+    // -- Display number --------------------------------------------
+
+    /// Cache the display number once XWayland reports Ready. The field
+    /// is currently write-only at the public API level (no downstream
+    /// reader) — retained because the stashing site exports the same
+    /// value to the `DISPLAY` env var and IPC notification, so the
+    /// cache exists to support a future consumer without touching
+    /// main's event-loop bootstrap.
+    pub fn set_display(&mut self, display: u32) {
+        self.display = Some(display);
+    }
+
+    // -- Supervisor ------------------------------------------------
+
+    /// Mutable access to the supervisor for arming calloop watches
+    /// and driving the spawn state machine.
+    pub fn integration_mut(&mut self) -> Option<&mut XwlsIntegration> {
+        self.integration.as_mut()
+    }
+
+    /// Install the supervisor. Called from `main` after sockets bind.
+    pub fn set_integration(&mut self, integration: XwlsIntegration) {
+        self.integration = Some(integration);
+    }
+
+    /// Drop the supervisor on a fatal init error so the rest of the
+    /// compositor keeps running without XWayland.
+    pub fn clear_integration(&mut self) {
+        self.integration = None;
+    }
+
+    // -- Pending child command -------------------------------------
+
+    /// Park a command to be spawned once XWayland reports Ready.
+    pub fn set_pending_command(&mut self, cmd: PendingCommand) {
+        self.pending_command = Some(cmd);
+    }
+
+    /// Drain the parked command (exactly once).
+    pub fn take_pending_command(&mut self) -> Option<PendingCommand> {
+        self.pending_command.take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `XwlsIntegration` owns pre-bound X11 sockets + a calloop
+    // `channel::Sender` and has no Default — constructing one in a
+    // unit test is out of scope. Its slot (set / integration_mut /
+    // clear) is covered by the e2e suite. Everything else (display
+    // cache, pending_command mailbox) is pure logic.
+
+    fn sample_cmd() -> PendingCommand {
+        PendingCommand {
+            command: "emacs".into(),
+            args: vec!["-nw".into()],
+            standalone: false,
+        }
+    }
+
+    #[test]
+    fn default_is_empty_on_all_three_slots() {
+        let s = XwaylandState::default();
+        assert!(s.display.is_none());
+        assert!(s.pending_command.is_none());
+        assert!(s.integration.is_none());
+    }
+
+    #[test]
+    fn set_display_caches_the_number() {
+        let mut s = XwaylandState::default();
+        s.set_display(42);
+        assert_eq!(s.display, Some(42));
+    }
+
+    #[test]
+    fn set_display_overwrites_previous_value() {
+        // Guards against a future where XWayland restarts mid-session —
+        // the latest display wins.
+        let mut s = XwaylandState::default();
+        s.set_display(1);
+        s.set_display(2);
+        assert_eq!(s.display, Some(2));
+    }
+
+    #[test]
+    fn pending_command_set_then_take() {
+        let mut s = XwaylandState::default();
+        assert!(s.take_pending_command().is_none());
+
+        s.set_pending_command(sample_cmd());
+        assert!(
+            s.pending_command.is_some(),
+            "set_pending_command parks the value"
+        );
+
+        let taken = s.take_pending_command().expect("take returns what was set");
+        assert_eq!(taken.command, "emacs");
+        assert_eq!(taken.args, vec!["-nw".to_string()]);
+        assert!(!taken.standalone);
+
+        assert!(
+            s.pending_command.is_none(),
+            "take drains — second read is None"
+        );
+        assert!(s.take_pending_command().is_none());
+    }
+
+    #[test]
+    fn set_pending_command_overwrites_previous() {
+        // If the user somehow re-arms a command before the first is
+        // drained, the second wins. Mirrors the flat-assignment
+        // semantics that existed before extraction.
+        let mut s = XwaylandState::default();
+        s.set_pending_command(PendingCommand {
+            command: "old".into(),
+            args: vec![],
+            standalone: true,
+        });
+        s.set_pending_command(PendingCommand {
+            command: "new".into(),
+            args: vec!["-flag".into()],
+            standalone: false,
+        });
+        let taken = s.take_pending_command().unwrap();
+        assert_eq!(taken.command, "new");
+        assert_eq!(taken.args, vec!["-flag".to_string()]);
+        assert!(!taken.standalone);
+    }
+
+    #[test]
+    fn display_and_pending_command_are_independent() {
+        let mut s = XwaylandState::default();
+        s.set_display(7);
+        s.set_pending_command(sample_cmd());
+
+        assert_eq!(s.display, Some(7));
+        assert!(s.pending_command.is_some());
+
+        let _ = s.take_pending_command();
+        assert_eq!(
+            s.display,
+            Some(7),
+            "draining the command must not touch the display cache"
+        );
+    }
+
+    #[test]
+    fn integration_mut_none_by_default() {
+        let mut s = XwaylandState::default();
+        assert!(s.integration_mut().is_none());
+    }
+
+    #[test]
+    fn clear_integration_is_no_op_when_already_empty() {
+        let mut s = XwaylandState::default();
+        s.clear_integration();
+        assert!(s.integration_mut().is_none());
+    }
+}

--- a/crates/emskin/src/tick.rs
+++ b/crates/emskin/src/tick.rs
@@ -10,7 +10,7 @@ use crate::workspace::Workspace;
 /// IPC dispatch, clipboard events, and pending geometry timeouts.
 pub fn event_loop_tick(state: &mut EmskinState) {
     // --- Check if Emacs child process has exited ---
-    if let Some(ref mut child) = state.emacs_child {
+    if let Some(child) = state.emacs.child_mut() {
         if let Ok(Some(status)) = child.try_wait() {
             tracing::info!("Emacs exited with {status}, stopping compositor");
             state.loop_signal.stop();
@@ -216,10 +216,7 @@ fn detect_dead_workspaces(state: &mut EmskinState) {
     }
 
     // Detect active Emacs frame death.
-    if state.detect_emacs
-        && state.emacs_surface.as_ref().is_some_and(|s| !s.is_alive())
-        && state.initial_size_settled
-    {
+    if state.emacs.main_died() {
         if let Some(&fallback_id) = state.workspace.inactive.keys().next() {
             tracing::info!("active Emacs died, switching to workspace {fallback_id}");
             state.switch_workspace(fallback_id);

--- a/crates/emskin/src/winit.rs
+++ b/crates/emskin/src/winit.rs
@@ -19,7 +19,7 @@ use smithay::{
         pointer::{CursorImageStatus, CursorImageSurfaceData},
     },
     output::{Mode, Output, PhysicalProperties, Scale, Subpixel},
-    reexports::{calloop::EventLoop, wayland_server::Resource},
+    reexports::calloop::EventLoop,
     utils::{Logical, Physical, Rectangle, Size, Transform, SERIAL_COUNTER},
     wayland::compositor::with_states,
 };
@@ -60,10 +60,9 @@ fn apply_pending_state(state: &mut EmskinState, backend: &mut WinitGraphicsBacke
         backend.window().set_ime_allowed(enabled);
     }
 
-    if state.cursor_changed {
-        state.cursor_changed = false;
+    if let Some(status) = state.cursor.take_changed() {
         let window = backend.window();
-        match &state.cursor_status {
+        match status {
             CursorImageStatus::Named(icon) => {
                 window.set_cursor_visible(true);
                 window.set_cursor(winit_crate::window::Cursor::Icon(*icon));
@@ -164,11 +163,9 @@ fn render_frame(
 
         // Software cursor (topmost of extras): used for Surface cursors
         // (GTK3/Emacs) that can't be forwarded via winit's CursorIcon API.
-        if let CursorImageStatus::Surface(ref surface) = state.cursor_status {
-            if !surface.is_alive() {
-                state.cursor_status = CursorImageStatus::default_named();
-                state.cursor_changed = true;
-            } else if let Some(pointer) = state.seat.get_pointer() {
+        state.cursor.ensure_alive();
+        if let CursorImageStatus::Surface(surface) = state.cursor.status() {
+            if let Some(pointer) = state.seat.get_pointer() {
                 if let Err(e) = import_surface_tree(renderer, surface) {
                     tracing::warn!("cursor import_surface_tree failed: {e:?}");
                 } else {

--- a/crates/emskin/src/winit.rs
+++ b/crates/emskin/src/winit.rs
@@ -42,7 +42,7 @@ fn apply_pending_state(state: &mut EmskinState, backend: &mut WinitGraphicsBacke
         backend.window().set_title(&title);
     }
 
-    if let Some(fullscreen) = state.pending_fullscreen.take() {
+    if let Some(fullscreen) = state.emacs.take_pending_fullscreen() {
         if fullscreen {
             backend
                 .window()
@@ -52,7 +52,7 @@ fn apply_pending_state(state: &mut EmskinState, backend: &mut WinitGraphicsBacke
         }
     }
 
-    if let Some(maximize) = state.pending_maximize.take() {
+    if let Some(maximize) = state.emacs.take_pending_maximize() {
         backend.window().set_maximized(maximize);
     }
 
@@ -368,7 +368,7 @@ pub fn init_winit(
         backend
             .window()
             .set_fullscreen(Some(winit_crate::window::Fullscreen::Borderless(None)));
-        state.pending_fullscreen = Some(true);
+        state.emacs.request_fullscreen(true);
     } else {
         backend.window().set_maximized(true);
     }

--- a/crates/emskin/src/winit.rs
+++ b/crates/emskin/src/winit.rs
@@ -153,10 +153,10 @@ fn render_frame(
 
         // Edge-detect Emacs connection and trigger `splash.dismiss` once.
         let emacs_now = state.emacs_surface.is_some();
-        if emacs_now && !state.last_emacs_connected {
-            state.splash.borrow_mut().dismiss();
+        if emacs_now && !state.effects.last_emacs_connected {
+            state.effects.splash.borrow_mut().dismiss();
         }
-        state.last_emacs_connected = emacs_now;
+        state.effects.last_emacs_connected = emacs_now;
 
         // Non-effect elements: software cursor, layer shell surfaces, window
         // mirrors. emskin assembles these itself.
@@ -229,7 +229,7 @@ fn render_frame(
             renderer,
             &mut framebuffer,
             &state.workspace.active_space,
-            &mut state.effect_chain,
+            &mut state.effects.chain,
             &effect_ctx,
             extras,
             damage_tracker,
@@ -289,14 +289,22 @@ fn render_frame(
     // dot stays in lockstep with whatever the recorder actually is.
     let now = state.start_time.elapsed();
     let overlay_at = state.recorder.overlay_started_at(now);
-    state.recorder_overlay.borrow_mut().set_active(overlay_at);
+    state
+        .effects
+        .recorder_overlay
+        .borrow_mut()
+        .set_active(overlay_at);
 
     // Recording ⇆ KeyCast linkage. Edge-trigger only so user toggles
     // (`SetKeyCast` IPC) outside a recording session aren't stomped.
     let recording_active = overlay_at.is_some();
-    if recording_active != state.last_recording_active {
-        state.last_recording_active = recording_active;
-        state.key_cast.borrow_mut().set_enabled(recording_active);
+    if recording_active != state.effects.last_recording_active {
+        state.effects.last_recording_active = recording_active;
+        state
+            .effects
+            .key_cast
+            .borrow_mut()
+            .set_enabled(recording_active);
         tracing::debug!(
             "key_cast auto-{} (recording {})",
             if recording_active { "on" } else { "off" },

--- a/crates/emskin/src/winit.rs
+++ b/crates/emskin/src/winit.rs
@@ -38,7 +38,7 @@ fn make_mode(size: Size<i32, Physical>) -> Mode {
 }
 
 fn apply_pending_state(state: &mut EmskinState, backend: &mut WinitGraphicsBackend<GlesRenderer>) {
-    if let Some(title) = state.emacs_title.take() {
+    if let Some(title) = state.emacs.take_title() {
         backend.window().set_title(&title);
     }
 
@@ -151,7 +151,7 @@ fn render_frame(
             .unwrap_or_else(|| Rectangle::from_size(output_size_log));
 
         // Edge-detect Emacs connection and trigger `splash.dismiss` once.
-        let emacs_now = state.emacs_surface.is_some();
+        let emacs_now = state.emacs.has_main_surface();
         if emacs_now && !state.effects.last_emacs_connected {
             state.effects.splash.borrow_mut().dismiss();
         }
@@ -436,7 +436,7 @@ pub fn init_winit(
                         map.arrange();
                     }
 
-                    if state.initial_size_settled {
+                    if state.emacs.size_settled() {
                         // Re-lays out every Emacs frame against the fresh
                         // non_exclusive_zone and broadcasts SurfaceSize — also
                         // sets needs_redraw.


### PR DESCRIPTION
## Summary

Stacked on top of #59. Completes the four remaining substruct follow-ups from #59's checklist, in four commits each scoped to one extraction and built under strict TDD (RED → GREEN → REFACTOR):

| Commit | Fields pulled | New methods added |
|---|---|---|
| [f0e19a6](../commit/f0e19a6) `EffectsState` | 11: `effect_chain` + 7 typed overlay handles + 3 edge-detect latches | `reset_on_workspace_switch` |
| [4a0e13a](../commit/4a0e13a) `CursorState` | 3: `cursor_status`, `cursor_changed`, `last_pointer_raw_loc` | `set_image`, `take_changed`, `ensure_alive`, `reset_on_workspace_switch`, `consume_raw_location` |
| [6b5e043](../commit/6b5e043) `EmacsState` | 6: `emacs_surface`, `emacs_child`, `emacs_title`, `emacs_app_id`, `detect_emacs`, `initial_size_settled` | `should_claim_main`, `main_died`, `is_main_surface`, plus getters/setters |
| [299af7e](../commit/299af7e) dissolve `pending_*` | 5: `pending_fullscreen`/`maximize` → EmacsState; `xdisplay`/`xwls`/`pending_command` → new `XwaylandState` | `request_fullscreen`, `take_pending_fullscreen`, `request_maximize`, `take_pending_maximize` on EmacsState; full XwaylandState API |

### Why four commits instead of one

Each extraction is behaviour-preserving and independently verifiable. Separate commits let a reviewer check each semantic move in isolation — the alternative (one big diff) obscures whether a call-site change corresponds to the right substruct.

### Why `dissolve pending_*` instead of a standalone `PendingBackendState`

The original plan proposed `PendingBackendState` as a sibling substruct. The cosmic-comp cross-reference ([#59 comment](https://github.com/emskin/emskin/pull/59#issuecomment-4295852766)) found that cosmic puts `pending_windows/pending_layers/pending_activations` inside `Shell` rather than a sibling struct — pending_* fields belong with their semantic owner, not in a grab bag. We follow that rule:
- `pending_fullscreen` / `pending_maximize` — host-window requests triggered by the Emacs surface → absorbed into `EmacsState` alongside `title` / `app_id` (same "write from handler, drain in `apply_pending_state`" mailbox pattern).
- `pending_command` — deferred child spawn waiting for XWayland readiness → absorbed into the new `XwaylandState` alongside `xdisplay` and `xwls`.

## Impact

`EmskinState` drops from **~45 flat fields pre-#59 → ~17 fields** after this PR lands (structural handles + substructs). Remaining flat fields are all either external handles (`loop_signal`, `backend`, `seat`, …) or intentionally uncontained (`bar_child`, `needs_redraw`, `recorder`) — no obvious further substruct extractions.

## TDD evidence

Each commit's test module was written **before** its impl via the full `todo!()` → RED → GREEN cycle:
- EffectsState: no dedicated unit tests (composition glue; covered by e2e)
- CursorState: **14 unit tests**
- EmacsState: **16 unit tests** (incl. 8 added in the pending-dissolve commit)
- XwaylandState: **8 unit tests**

Surface-dependent branches (`ensure_alive` dead-surface, `main_died` with a live `WlSurface`, `XwlsIntegration` live branch) require a Wayland `Display` + `Client` and are covered by the existing e2e suite.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build -p emez && cargo test -p emskin` — **103 unit tests** (was 57 pre-#59, +46 from this stack) + all e2e pass
- [x] Manual: the cosmic-comp cross-reference items from #59's checklist are all either applied (pending_* dissolution, XwaylandState shape) or explicitly deferred with rationale (State/Runtime split, per-seat focus userdata, Shell umbrella — all single-seat or require future multi-seat plumbing)
- [ ] Requires #59 merged first — PR base is set to `refactor/state-cohesion`. Once #59 lands on main, GitHub will re-target this automatically.

## Deferred / flagged

- **`emacs_app_id`** is stored on the struct but never read downstream; same for **`xwayland.display`**. Both are commit-noted as "write-only cache; retiring is a separate decision" — preserving them keeps this refactor behaviour-neutral.
- e2e `wait_for_path(sock_path, 10s)` was observed to flake once under heavy parallel load (unrelated to this stack; root cause is emez startup timing on loaded machines). Not fixed here per the decision to keep the refactor scoped.