### PR TITLE
fix(ime): re-evaluate host IME after every tick to catch late text_input bind

### DIFF
--- a/crates/emskin/src/state/ime.rs
+++ b/crates/emskin/src/state/ime.rs
@@ -26,6 +26,12 @@ pub struct ImeBridge {
     /// (write-once, read-once semantic — the `Option` distinguishes
     /// "no change to apply" from "apply false").
     ime_enabled: Option<bool>,
+    /// Last value `take_ime_enabled` returned (i.e. last value the
+    /// winit backend was told). Used by [`Self::resync`] to suppress
+    /// no-op re-evaluations: tick-driven re-derivation is a hot path,
+    /// and we only want to write the mailbox when the answer differs
+    /// from what's already committed downstream.
+    last_committed: Option<bool>,
 }
 
 impl ImeBridge {
@@ -37,11 +43,12 @@ impl ImeBridge {
         Self {
             focused_surface: None,
             ime_enabled: None,
+            last_committed: None,
         }
     }
 
-    /// Bridge text_input enter/leave on keyboard focus change and decide
-    /// whether host IME should be enabled for the new focus.
+    /// Bridge text_input enter/leave on keyboard focus change and queue
+    /// a re-evaluation of host IME for the new focus.
     ///
     /// `new_focus` is the focused surface projected from
     /// `KeyboardFocusTarget` via `WaylandFocus::wl_surface()` — X clients
@@ -50,13 +57,43 @@ impl ImeBridge {
         let ti = seat.text_input();
         let old = self.focused_surface.take();
         transition_focus(ti, old, &new_focus);
-        let enabled = focused_client_has_text_input(ti);
-        tracing::debug!(
-            "IME focus_changed: has_focus={} ime_enabled={enabled}",
-            new_focus.is_some()
-        );
+        tracing::debug!("IME focus_changed: has_focus={}", new_focus.is_some());
         self.focused_surface = new_focus;
-        self.ime_enabled = Some(enabled);
+        self.resync(seat);
+    }
+
+    /// Re-derive "should host IME be allowed" from the seat's current
+    /// text_input state and queue an update if the answer changed since
+    /// the last winit commit.
+    ///
+    /// **Why this exists**: the answer is a function of (focused
+    /// surface, focused client's bound text_input instances). It can
+    /// change in three ways:
+    ///
+    /// 1. focus moves to a different surface — handled by
+    ///    [`Self::on_focus_changed`]
+    /// 2. the focused client late-binds `text_input_v3` (pgtk Emacs
+    ///    binds *after* its initial configure, i.e. after the
+    ///    `new_toplevel` keyboard-focus event runs)
+    /// 3. the focused client destroys its text_input instance
+    ///
+    /// (2) and (3) have no smithay callback. To catch them we resync
+    /// once per event-loop tick (after `dispatch_clients` has had a
+    /// chance to process new bind / destroy requests). Cheap: an
+    /// in-process probe + an `Option<bool>` compare; only writes the
+    /// mailbox when the answer actually differs.
+    pub fn resync(&mut self, seat: &Seat<EmskinState>) {
+        self.resync_from_handle(seat.text_input());
+    }
+
+    /// Inner re-evaluation against a raw [`TextInputHandle`]. Split out
+    /// so unit tests can drive the state machine without building a
+    /// full `Seat`. Production callers go through [`Self::resync`].
+    fn resync_from_handle(&mut self, ti: &TextInputHandle) {
+        let want = focused_client_has_text_input(ti);
+        if self.last_committed != Some(want) {
+            self.ime_enabled = Some(want);
+        }
     }
 
     /// Forward a host IME event to the focused text_input_v3 client and
@@ -112,23 +149,28 @@ impl ImeBridge {
 
     /// Drain the deferred `set_ime_allowed` decision, if any. Called
     /// from the winit render loop where the backend is accessible.
+    /// Records the drained value in `last_committed` so future
+    /// [`Self::resync`] calls can suppress no-op writes.
     pub fn take_ime_enabled(&mut self) -> Option<bool> {
         let taken = self.ime_enabled.take();
         if let Some(enabled) = taken {
             tracing::debug!("IME: applying set_ime_allowed({enabled})");
+            self.last_committed = Some(enabled);
         }
         taken
     }
 
     /// Clear state on workspace switch — stale surface refs would
-    /// otherwise route text_input events to the wrong client. The
-    /// `Some(false)` pending decision also disables host IME during the
-    /// switch transient; the next `on_focus_changed` will re-enable it
+    /// otherwise route text_input events to the wrong client. Forces
+    /// host IME off during the switch transient; the next
+    /// [`Self::on_focus_changed`] / [`Self::resync`] will re-enable it
     /// if the incoming focus has text_input_v3 bound.
     pub fn reset_on_workspace_switch(&mut self) {
         tracing::debug!("IME: reset on workspace switch");
         self.focused_surface = None;
-        self.ime_enabled = Some(false);
+        if self.last_committed != Some(false) {
+            self.ime_enabled = Some(false);
+        }
     }
 }
 
@@ -191,3 +233,118 @@ fn sync_ime_cursor_area(
 }
 
 smithay::delegate_text_input_manager!(EmskinState);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smithay::wayland::text_input::TextInputHandle;
+
+    /// Build an `ImeBridge` without going through `new` (which needs a
+    /// live `DisplayHandle`). The tests below only exercise the
+    /// mailbox / committed-cache state machine, which is independent
+    /// of the smithay registration in `new`.
+    fn fresh_bridge() -> ImeBridge {
+        ImeBridge {
+            focused_surface: None,
+            ime_enabled: None,
+            last_committed: None,
+        }
+    }
+
+    /// A default `TextInputHandle` has no instances, so
+    /// `with_focused_text_input` never fires its callback ⇒
+    /// `focused_client_has_text_input` returns `false`. Sufficient to
+    /// exercise the "no client text_input bound" branch of resync,
+    /// which is the exact production scenario the bug appears in.
+    fn empty_handle() -> TextInputHandle {
+        TextInputHandle::default()
+    }
+
+    #[test]
+    fn resync_first_call_writes_disable_into_mailbox() {
+        let mut bridge = fresh_bridge();
+        bridge.resync_from_handle(&empty_handle());
+        assert_eq!(bridge.ime_enabled, Some(false));
+    }
+
+    #[test]
+    fn take_ime_enabled_records_last_committed() {
+        let mut bridge = fresh_bridge();
+        bridge.resync_from_handle(&empty_handle());
+        let taken = bridge.take_ime_enabled();
+        assert_eq!(taken, Some(false));
+        assert_eq!(bridge.last_committed, Some(false));
+        assert!(bridge.ime_enabled.is_none(), "mailbox drained");
+    }
+
+    #[test]
+    fn resync_is_silent_when_answer_matches_last_committed() {
+        // Regression guard for the "polled per tick" property: if the
+        // derived answer hasn't changed since winit committed it, no
+        // mailbox write happens, no spurious `set_ime_allowed` syscall.
+        let mut bridge = fresh_bridge();
+        bridge.resync_from_handle(&empty_handle());
+        bridge.take_ime_enabled(); // commits Some(false)
+
+        bridge.resync_from_handle(&empty_handle()); // same answer
+        assert!(
+            bridge.ime_enabled.is_none(),
+            "resync must not re-queue when last_committed already matches"
+        );
+    }
+
+    #[test]
+    fn resync_overwrites_undrained_mailbox_when_value_unchanged() {
+        // Edge case: two ticks in a row with no take in between, both
+        // see `false`. The mailbox holds `Some(false)` after tick 1.
+        // Tick 2's resync sees `last_committed = None` (never drained),
+        // so the answer "differs" from the cache → mailbox stays at
+        // `Some(false)`. Idempotent.
+        let mut bridge = fresh_bridge();
+        bridge.resync_from_handle(&empty_handle());
+        assert_eq!(bridge.ime_enabled, Some(false));
+        bridge.resync_from_handle(&empty_handle());
+        assert_eq!(
+            bridge.ime_enabled,
+            Some(false),
+            "second resync without intervening take is idempotent"
+        );
+    }
+
+    #[test]
+    fn reset_on_workspace_switch_queues_disable_when_last_was_enabled() {
+        // Workspace switch must force host IME off so a pre-existing
+        // `set_ime_allowed(true)` doesn't leak across the boundary.
+        let mut bridge = fresh_bridge();
+        bridge.last_committed = Some(true); // simulate prior IME-on workspace
+        bridge.reset_on_workspace_switch();
+        assert_eq!(bridge.ime_enabled, Some(false));
+    }
+
+    #[test]
+    fn reset_on_workspace_switch_is_silent_when_already_disabled() {
+        // If the previous workspace already had IME off, the reset
+        // must not queue a redundant winit `set_ime_allowed(false)`.
+        let mut bridge = fresh_bridge();
+        bridge.last_committed = Some(false);
+        bridge.reset_on_workspace_switch();
+        assert!(
+            bridge.ime_enabled.is_none(),
+            "no redundant winit syscall when workspace switch doesn't change IME state"
+        );
+    }
+
+    #[test]
+    fn reset_clears_focused_surface_regardless_of_ime_state() {
+        // The focused-surface clearing path is the legacy correctness
+        // requirement (avoid stale text_input routing); guard it
+        // doesn't regress when `last_committed` short-circuits the IME
+        // mailbox write.
+        let mut bridge = fresh_bridge();
+        bridge.last_committed = Some(false);
+        // Can't easily set focused_surface to a real WlSurface in a
+        // unit test, but reset must leave it as None either way.
+        bridge.reset_on_workspace_switch();
+        assert!(bridge.focused_surface.is_none());
+    }
+}

--- a/crates/emskin/src/tick.rs
+++ b/crates/emskin/src/tick.rs
@@ -101,6 +101,26 @@ pub fn event_loop_tick(state: &mut EmskinState) {
         }
         tracing::debug!("embedded app window_id={window_id} geometry force-committed (timeout)");
     }
+
+    // --- Re-evaluate host IME after this tick's Wayland traffic ---
+    // smithay does not expose a callback when a client late-binds or
+    // destroys a `text_input_v3` instance. The decision "should host
+    // IME be allowed?" is a function of (focused surface, focused
+    // client's bound text_input instances) — both of which can change
+    // between focus_changed events.
+    //
+    // Concretely: pgtk Emacs binds text_input *after* its initial
+    // configure, i.e. after the `new_toplevel` keyboard-focus event
+    // fires. The original `on_focus_changed` evaluation gave `false`
+    // because the bind hadn't happened yet, and the answer never got
+    // re-evaluated until the user cycled focus through another app.
+    //
+    // Resync once per tick (after dispatch_clients has processed any
+    // bind/destroy in this batch). Cost is a single uncontested mutex
+    // lock + a tiny instance-list scan; the mailbox is only written
+    // when the answer differs from `last_committed`, so steady state
+    // is silent.
+    state.ime.resync(&state.seat);
 }
 
 fn process_pending_toplevels(state: &mut EmskinState) {


### PR DESCRIPTION
## The bug

When pgtk Emacs is the first toplevel, **IME does not work on first focus** — the user has to switch to another app and back before Chinese / Japanese / Korean input starts working. Reproduced on every cold start of emskin with Emacs.

Same workaround that PR #40 documented; same root cause.

## Root cause

\"Should host IME be allowed?\" is a function of:

1. The currently focused surface
2. Whether the focused client has bound a \`text_input_v3\` instance

Pre-fix \`ImeBridge::on_focus_changed\` evaluated this **once**, at focus-change time, and cached the answer in a one-shot mailbox.

But Wayland binding is **asynchronous**: pgtk Emacs binds \`text_input_v3\` *after* it processes the initial configure — i.e. *after* the \`new_toplevel\` keyboard-focus event that triggers \`on_focus_changed\` fires. So:

\`\`\`
T3  emskin: new_toplevel → keyboard.set_focus(emacs)
       → focus_changed → ImeBridge::on_focus_changed
       → with_focused_text_input(...) returns false (Emacs hasn't bound yet)
       → ime_enabled = Some(false)        ← LOCKED IN
T5  emacs: bind text_input_v3, create instance, send Enable
T6  emskin: dispatch, but no event re-evaluates ime_enabled
       → host fcitx5 stays disabled forever (until user cycles focus)
\`\`\`

The same shape applies in reverse — a client that destroys its text_input instance leaves host IME enabled with no consumer.

## Fix

Treat host-IME-allowed as **derived state**, not a stored decision. Re-derive on every event source that can change the inputs:

| # | Event | Wired |
|---|---|---|
| 1 | focused surface changes | \`focus_changed\` (existing) |
| 2 | focused client binds \`text_input_v3\` | **per-tick \`resync\` (new)** |
| 3 | focused client destroys text_input | per-tick \`resync\` (new) |

smithay does **not** expose bind/destroy callbacks for text_input. The cheapest reliable trigger is an event-loop-tick poll, after \`dispatch_clients\` has had a chance to process new client requests.

## Cost analysis

\`ImeBridge::resync\` does an in-process probe: single uncontested mutex lock + tiny instance-list scan, **no syscall, no I/O**. The mailbox is only written when the answer differs from \`last_committed\` (a new field that records whatever winit last applied). Steady state is silent: the hot tick path becomes ~50 ns of compare-and-skip.

\`take_ime_enabled\` updates \`last_committed\` on drain so subsequent resyncs short-circuit. \`reset_on_workspace_switch\` likewise short-circuits when the previous state was already \`false\`, avoiding redundant winit \`set_ime_allowed(false)\` syscalls on every workspace switch where IME was already off.

## Test plan

- [x] \`cargo clippy --workspace -- -D warnings\` — zero warnings
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo build -p emez && cargo test -p emskin\` — **116 unit tests** (was 109, +7) + all e2e pass
- [x] **7 new unit tests** on \`ImeBridge\` cover the state machine:
  - first \`resync\` writes disable into mailbox
  - \`take_ime_enabled\` records last_committed
  - matching resync is silent (no spurious mailbox write)
  - undrained mailbox is overwritten idempotently
  - workspace switch from IME-on queues disable
  - workspace switch from IME-off is silent (no redundant syscall)
  - reset always clears focused_surface
- [ ] Manual: cold-start emskin with Emacs, verify Chinese input works on the **first** focus without needing to cycle through another app. *(requires user verification on a machine with fcitx5)*

## Relation to PR #40

[PR #40](https://github.com/emskin/emskin/pull/40) reported the same user-visible bug and proposed a hammer fix: hard-set \`pending_ime_allowed = Some(true)\` in \`new_toplevel\` for the Emacs branch, betting that Emacs *will* bind text_input. That patch:

- Doesn't compile against current main (\`pending_ime_allowed\` was moved into \`ImeBridge::ime_enabled\` by #59)
- Hard-codes Emacs-specific behaviour into the xdg_shell handler
- Leaves the same bug for any other client with the same late-bind pattern
- Doesn't address the symmetric destroy case

This PR fixes the underlying timing model, so any client (not just Emacs) with late-bound text_input is handled correctly, and PR #40 can be closed.